### PR TITLE
HTTPError extract details and HTTP field errors in workingData

### DIFF
--- a/packages/utils/src/HTTPError.ts
+++ b/packages/utils/src/HTTPError.ts
@@ -1,6 +1,7 @@
 export interface HTTPProblemDetails {
     title: string;
     detail: string;
+    fields?: Record<string, string>;
 }
 
 type ExtractDetails = (response: Response) => Promise<HTTPProblemDetails>;
@@ -10,6 +11,7 @@ const defaultExtractDetails: ExtractDetails = async (response) => {
         return {
             title: details.title,
             detail: details.detail,
+            fields: details.fields,
         };
     } catch (error) {
         return {


### PR DESCRIPTION
This commit allows passing an extract details function to HTTPError, to allow workingData to display details and a toast message on failure. Includes a default that follows HTTP Problem Details. https://tools.ietf.org/html/rfc7807

For example:
``` tsx
throw new HTTPError(response, aysnc (r) => { 
  const details = await r.json(); 
  return {
    title: 'An error occured!', 
    detail: details.message, 
  }; 
});
```