### PR TITLE
Focus Safari & Focus trap

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -90,9 +90,11 @@ export namespace Components {
         "positionX": string;
         "positionY": string;
         "target": string;
+        "trapFocus": boolean;
     }
     interface EsPopper {
         "backdrop": boolean;
+        "trapFocus": boolean;
     }
     interface EsPopperInner {
         "setPosition": (position: Position) => Promise<void>;
@@ -424,10 +426,12 @@ declare namespace LocalJSX {
         "positionX"?: string;
         "positionY"?: string;
         "target"?: string;
+        "trapFocus"?: boolean;
     }
     interface EsPopper {
         "backdrop"?: boolean;
         "onRequestClose"?: (event: CustomEvent<any>) => void;
+        "trapFocus"?: boolean;
     }
     interface EsPopperInner {
     }

--- a/packages/components/src/components/es-modal/es-modal.tsx
+++ b/packages/components/src/components/es-modal/es-modal.tsx
@@ -1,4 +1,14 @@
-import { Component, h, Host, Event, EventEmitter, Prop } from '@stencil/core';
+import { delegateFocus, trapFocus } from '@eventstore/utils';
+import {
+    Component,
+    h,
+    Host,
+    Event,
+    EventEmitter,
+    Prop,
+    getElement,
+    Listen,
+} from '@stencil/core';
 
 @Component({
     tag: 'es-modal',
@@ -10,6 +20,25 @@ export class Modal {
     @Prop() header: boolean = true;
     @Prop() footer: boolean = true;
 
+    private releaseFocus?: () => void;
+
+    componentDidLoad() {
+        delegateFocus(getElement(this));
+    }
+
+    connectedCallback() {
+        this.releaseFocus = trapFocus(getElement(this));
+    }
+
+    disconnectedCallback() {
+        this.releaseFocus?.();
+    }
+
+    @Listen('keyup') onEscape(e: KeyboardEvent) {
+        if (e.key !== 'Escape') return;
+        this.requestClose.emit();
+    }
+
     render() {
         return (
             <Host>
@@ -17,6 +46,7 @@ export class Modal {
                     class={'close'}
                     role={'button'}
                     onClick={this.requestClose.emit}
+                    data-skip-focus-delegation
                 >
                     <es-icon icon={'close'} size={22} />
                 </button>

--- a/packages/components/src/components/es-popover/components/es-popper/es-popper.tsx
+++ b/packages/components/src/components/es-popover/components/es-popper/es-popper.tsx
@@ -1,4 +1,14 @@
-import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+import {
+    Component,
+    Event,
+    EventEmitter,
+    getElement,
+    h,
+    Host,
+    Listen,
+    Prop,
+} from '@stencil/core';
+import { delegateFocus, trapFocus } from '@eventstore/utils';
 
 @Component({
     tag: 'es-popper',
@@ -8,6 +18,28 @@ import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 export class Popper {
     @Event() requestClose!: EventEmitter;
     @Prop() backdrop: boolean = false;
+    @Prop({ attribute: 'trap-focus' }) trapFocus: boolean = false;
+
+    private releaseFocus?: () => void;
+
+    componentDidLoad() {
+        if (!this.trapFocus) return;
+        delegateFocus(getElement(this));
+    }
+
+    connectedCallback() {
+        if (!this.trapFocus) return;
+        this.releaseFocus = trapFocus(getElement(this));
+    }
+
+    disconnectedCallback() {
+        this.releaseFocus?.();
+    }
+
+    @Listen('keyup') onEscape(e: KeyboardEvent) {
+        if (e.key !== 'Escape') return;
+        this.requestClose.emit();
+    }
 
     render() {
         return (

--- a/packages/components/src/components/es-popover/components/es-popper/readme.md
+++ b/packages/components/src/components/es-popover/components/es-popper/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property   | Attribute  | Description | Type      | Default |
-| ---------- | ---------- | ----------- | --------- | ------- |
-| `backdrop` | `backdrop` |             | `boolean` | `false` |
+| Property    | Attribute    | Description | Type      | Default |
+| ----------- | ------------ | ----------- | --------- | ------- |
+| `backdrop`  | `backdrop`   |             | `boolean` | `false` |
+| `trapFocus` | `trap-focus` |             | `boolean` | `false` |
 
 
 ## Events

--- a/packages/components/src/components/es-popover/es-popover.tsx
+++ b/packages/components/src/components/es-popover/es-popover.tsx
@@ -23,6 +23,7 @@ export class Popover {
     @Prop() target = 'body';
     @Prop({ reflect: true }) open: boolean = false;
     @Prop() backdrop: boolean = false;
+    @Prop({ attribute: 'trap-focus' }) trapFocus: boolean = false;
 
     @Prop() positionY: string = 'top';
     @Prop() positionX: string = 'middle';
@@ -125,6 +126,7 @@ export class Popover {
 
         popper.style.opacity = '0';
         popper.setAttribute('backdrop', `${this.backdrop}`);
+        popper.setAttribute('trap-focus', `${this.trapFocus}`);
         popperInner.classList.add('inner');
 
         if (this.popperClass) {

--- a/packages/components/src/components/es-popover/readme.md
+++ b/packages/components/src/components/es-popover/readme.md
@@ -19,6 +19,7 @@
 | `positionX`   | `position-x`   |             | `string`              | `'middle'`  |
 | `positionY`   | `position-y`   |             | `string`              | `'top'`     |
 | `target`      | `target`       |             | `string`              | `'body'`    |
+| `trapFocus`   | `trap-focus`   |             | `boolean`             | `false`     |
 
 
 ## Events

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -5,7 +5,7 @@
         "allowUnreachableCode": false,
         "declaration": false,
         "experimentalDecorators": true,
-        "lib": ["dom", "es2017"],
+        "lib": ["dom", "es2019"],
         "moduleResolution": "node",
         "module": "esnext",
         "target": "es2017",

--- a/packages/editor/src/es-editor/es-editor.tsx
+++ b/packages/editor/src/es-editor/es-editor.tsx
@@ -4,7 +4,7 @@ import { editor } from 'monaco-editor';
 @Component({
     tag: 'es-editor',
     styleUrl: 'es-editor.css',
-    shadow: { delegatesFocus: true },
+    shadow: true,
 })
 export class YEditor {
     @Element() host!: HTMLEsEditorElement;

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -5,7 +5,7 @@
         "allowUnreachableCode": false,
         "declaration": false,
         "experimentalDecorators": true,
-        "lib": ["dom", "es2017"],
+        "lib": ["dom", "es2019"],
         "moduleResolution": "node",
         "module": "esnext",
         "target": "es2017",

--- a/packages/fields/src/components/es-checkbox/es-checkbox.tsx
+++ b/packages/fields/src/components/es-checkbox/es-checkbox.tsx
@@ -3,9 +3,7 @@ import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
 @Component({
     tag: 'es-checkbox',
     styleUrl: 'es-checkbox.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class EsCheckbox {
     @Event({ bubbles: true }) fieldchange!: EventEmitter;

--- a/packages/fields/src/components/es-input/es-input.tsx
+++ b/packages/fields/src/components/es-input/es-input.tsx
@@ -16,9 +16,7 @@ export interface MaskOptions {
 @Component({
     tag: 'es-input',
     styleUrl: 'es-input.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class EsInput {
     @Event({ bubbles: true }) fieldchange!: EventEmitter;

--- a/packages/fields/src/components/es-list-creator/es-list-creator.tsx
+++ b/packages/fields/src/components/es-list-creator/es-list-creator.tsx
@@ -18,9 +18,7 @@ import { Field } from '../Field/Field';
 @Component({
     tag: 'es-list-creator',
     styleUrl: 'es-list-creator.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class ListCreator {
     @Element() host!: HTMLEsListCreatorElement;

--- a/packages/fields/src/components/es-mega-input/es-mega-input.tsx
+++ b/packages/fields/src/components/es-mega-input/es-mega-input.tsx
@@ -5,9 +5,7 @@ import { Field } from '../Field/Field';
 @Component({
     tag: 'es-mega-input',
     styleUrl: 'es-mega-input.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class EsMegaInput {
     @Event({ bubbles: true }) fieldchange!: EventEmitter;

--- a/packages/fields/src/components/es-number-input/es-number-input.tsx
+++ b/packages/fields/src/components/es-number-input/es-number-input.tsx
@@ -4,9 +4,7 @@ import { Field } from '../Field/Field';
 @Component({
     tag: 'es-number-input',
     styleUrl: 'es-number-input.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class EsNumberInput {
     @Event({ bubbles: true }) fieldchange!: EventEmitter;

--- a/packages/fields/src/components/es-radio-card-group/es-radio-card-group.css
+++ b/packages/fields/src/components/es-radio-card-group/es-radio-card-group.css
@@ -97,6 +97,7 @@ input {
     position: absolute;
     opacity: 0;
     width: 0;
+    bottom: 0;
 }
 
 .label {

--- a/packages/fields/src/components/es-radio-card-group/es-radio-card-group.tsx
+++ b/packages/fields/src/components/es-radio-card-group/es-radio-card-group.tsx
@@ -24,9 +24,7 @@ export type RenderCard<T extends RadioCardGroupOption> = (
 @Component({
     tag: 'es-radio-card-group',
     styleUrl: 'es-radio-card-group.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class RadioCardGroup {
     @Event({ bubbles: true }) fieldchange!: EventEmitter;

--- a/packages/fields/src/components/es-select/es-select.tsx
+++ b/packages/fields/src/components/es-select/es-select.tsx
@@ -24,9 +24,7 @@ export type RenderSelectValue = (
 @Component({
     tag: 'es-select',
     styleUrl: 'es-select.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class EsSelect {
     @Element() host!: HTMLEsListCreatorElement;

--- a/packages/fields/src/components/es-switch/es-switch.tsx
+++ b/packages/fields/src/components/es-switch/es-switch.tsx
@@ -11,9 +11,7 @@ import {
 @Component({
     tag: 'es-switch',
     styleUrl: 'es-switch.css',
-    shadow: {
-        delegatesFocus: true,
-    },
+    shadow: true,
 })
 export class EsSwitch {
     @Event({ bubbles: true }) fieldchange!: EventEmitter;

--- a/packages/fields/src/utils/workingData/createWorkingData.ts
+++ b/packages/fields/src/utils/workingData/createWorkingData.ts
@@ -1,9 +1,10 @@
-import { HTTPError } from '@eventstore/utils';
+import { delegateFocus, HTTPError } from '@eventstore/utils';
 import { toast } from '@eventstore/components';
 import { logger } from '../logger';
 import { WorkingDataOptions, WorkingData, Severity } from '../../types';
 import { expandOptions } from './expandOptions';
 import { createStores } from './createStores';
+
 export const createWorkingData = <T extends object>(
     options: WorkingDataOptions<T>,
 ): WorkingData<T> => {
@@ -91,7 +92,7 @@ export const createWorkingData = <T extends object>(
                 for (const failure of failures) {
                     const ref = refs.get(failure);
                     if (!ref) continue;
-                    ref.focus({ preventScroll: true });
+                    delegateFocus(ref, { preventScroll: true });
                     ref.scrollIntoView({ behavior: 'smooth', block: 'center' });
                     break;
                 }

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -5,7 +5,7 @@
         "allowUnreachableCode": false,
         "declaration": false,
         "experimentalDecorators": true,
-        "lib": ["dom", "es2017"],
+        "lib": ["dom", "es2019"],
         "moduleResolution": "node",
         "module": "esnext",
         "target": "es2017",

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -4,7 +4,7 @@
         "allowUnreachableCode": false,
         "declaration": false,
         "experimentalDecorators": true,
-        "lib": ["dom", "es2017"],
+        "lib": ["dom", "es2019"],
         "moduleResolution": "node",
         "module": "esnext",
         "target": "es2017",

--- a/packages/utils/src/focus.ts
+++ b/packages/utils/src/focus.ts
@@ -1,0 +1,202 @@
+const tabbables = [
+    'button:enabled',
+    'select:enabled',
+    'textarea:enabled',
+    'input:enabled',
+
+    'a[href]',
+    'area[href]',
+
+    'summary',
+    'iframe',
+    'object',
+    'embed',
+
+    'audio[controls]',
+    'video[controls]',
+
+    '[tabindex]',
+    '[contenteditable]',
+    '[autofocus]',
+].join(',');
+
+const keyboardSkips = ['[tabindex="-1"]'].join(',');
+const delegationSkips = ['[data-skip-focus-delegation]', keyboardSkips].join(
+    ',',
+);
+
+const isFocusable = (node: Node, skip?: string): boolean =>
+    (node as HTMLElement).matches?.(tabbables) &&
+    !(
+        ((node as HTMLElement).tagName === 'INPUT' ||
+            (node as HTMLElement).tagName === 'BUTTON') &&
+        ((node as HTMLInputElement).type === 'hidden' ||
+            (node as HTMLInputElement).disabled)
+    ) &&
+    !(skip && (node as HTMLElement).matches?.(skip));
+
+const focusableElements = (
+    el: Node | HTMLElement,
+    skip?: string,
+): HTMLElement[] => {
+    if (isFocusable(el, skip)) {
+        return [el as HTMLElement];
+    }
+
+    if (el.nodeName === 'SLOT') {
+        return (el as HTMLSlotElement)
+            .assignedNodes()
+            .flatMap((n) => focusableElements(n, skip));
+    }
+
+    if ('shadowRoot' in el && el.shadowRoot) {
+        return Array.from(el.shadowRoot.childNodes).flatMap((n) =>
+            focusableElements(n, skip),
+        );
+    }
+
+    return Array.from(el.childNodes).flatMap((n) => focusableElements(n, skip));
+};
+
+const activeElement = (
+    el: Element | null = document.activeElement,
+): HTMLElement | null => {
+    if (!el || isFocusable(el)) return el as HTMLElement;
+    if (el.shadowRoot) return activeElement(el.shadowRoot.activeElement);
+    return null;
+};
+
+const orderedFocusableElements = (el: Node, skip?: string) =>
+    focusableElements(el, skip).sort(
+        (a, b) =>
+            (a as HTMLElement).tabIndex ?? 0 - (b as HTMLElement).tabIndex ?? 0,
+    );
+
+const firstFocusable = (
+    els: HTMLElement[],
+    skip: string,
+): HTMLElement | undefined => {
+    if (!els.length) return;
+    return els.find((el) => !el.matches(skip)) ?? els[0];
+};
+
+const lastFocusable = (els: HTMLElement[], skip: string) => {
+    return firstFocusable(els.reverse(), skip);
+};
+
+export const delegateFocus = (el: HTMLElement, focusOptions?: FocusOptions) => {
+    const els = orderedFocusableElements(el);
+    const active = activeElement();
+    if (active && els.includes(active)) return;
+    firstFocusable(els, delegationSkips)?.focus(focusOptions);
+};
+
+export const focusFirst = (el: HTMLElement, focusOptions?: FocusOptions) => {
+    const els = orderedFocusableElements(el);
+    firstFocusable(els, keyboardSkips)?.focus(focusOptions);
+};
+
+export const focusLast = (el: HTMLElement, focusOptions?: FocusOptions) => {
+    const els = orderedFocusableElements(el);
+    lastFocusable(els, keyboardSkips)?.focus(focusOptions);
+};
+
+const isFragment = (node: Node): node is ShadowRoot =>
+    node.nodeType === node.DOCUMENT_FRAGMENT_NODE;
+
+type Doc = Document | DocumentFragment;
+
+const hostPath = (node: Node) => {
+    let host = node;
+    let rootNode = node.getRootNode() as Doc;
+    const path = new Map<Doc, Node>();
+
+    path.set(rootNode, host);
+
+    while (isFragment(rootNode)) {
+        host = rootNode.host;
+        rootNode = host.getRootNode() as Doc;
+        path.set(rootNode, host);
+    }
+
+    return path;
+};
+
+export const trapFocus = (trap: HTMLElement, focusOptions?: FocusOptions) => {
+    const previousFocus = activeElement();
+    delegateFocus(trap, focusOptions);
+
+    const onFocusOutside = (event: FocusEvent) => {
+        event.preventDefault();
+
+        const [trueTarget] = event.composedPath() as Node[];
+
+        if (!trueTarget) {
+            return delegateFocus(trap, focusOptions);
+        }
+
+        const trapPath = hostPath(trap);
+        const targetPath = hostPath(trueTarget);
+
+        const sharedDocument = Array.from(targetPath.keys()).find((doc) =>
+            trapPath.has(doc),
+        );
+
+        if (!sharedDocument) {
+            return delegateFocus(trap, focusOptions);
+        }
+
+        const targetHost = targetPath.get(sharedDocument)!;
+        const trapHost = trapPath.get(sharedDocument)!;
+
+        const position = trapHost.compareDocumentPosition(targetHost);
+
+        if (position & document.DOCUMENT_POSITION_FOLLOWING) {
+            return focusFirst(trap, focusOptions);
+        }
+
+        if (position & document.DOCUMENT_POSITION_PRECEDING) {
+            return focusLast(trap, focusOptions);
+        }
+
+        return delegateFocus(trap, focusOptions);
+    };
+
+    const stopPropagation = (event: FocusEvent) => {
+        event.stopPropagation();
+    };
+
+    const trapTab = (event: KeyboardEvent) => {
+        if (event.key !== 'Tab') return;
+        const [trueTarget] = event.composedPath() as Node[];
+        const els = orderedFocusableElements(trap, keyboardSkips);
+
+        if (event.shiftKey) {
+            if (els[0] === trueTarget) {
+                event.preventDefault();
+                event.stopPropagation();
+                focusLast(trap, focusOptions);
+            }
+        } else if (els[els.length - 1] === trueTarget) {
+            event.preventDefault();
+            event.stopPropagation();
+            focusFirst(trap, focusOptions);
+        }
+    };
+
+    trap.addEventListener('focusin', stopPropagation);
+    trap.addEventListener('keydown', trapTab, { capture: true });
+    document.addEventListener('focusin', onFocusOutside);
+
+    return (returnFocus: boolean | FocusOptions = true) => {
+        trap.removeEventListener('focusin', stopPropagation);
+        trap.removeEventListener('keydown', trapTab, { capture: true });
+        document.removeEventListener('focusin', onFocusOutside);
+
+        if (returnFocus) {
+            previousFocus?.focus(
+                typeof returnFocus === 'boolean' ? undefined : returnFocus,
+            );
+        }
+    };
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,3 +2,4 @@ export { createLogger } from './createLogger/createLogger';
 export { extractOnly } from './extractOnly';
 export { findAssignedSlot } from './findAssignedSlot';
 export { HTTPError } from './HTTPError';
+export * from './focus';

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -5,7 +5,7 @@
         "allowUnreachableCode": false,
         "declaration": true,
         "experimentalDecorators": true,
-        "lib": ["dom", "es2017"],
+        "lib": ["dom", "es2019"],
         "moduleResolution": "node",
         "module": "esnext",
         "target": "es5",

--- a/tools/router-demo/tsconfig.json
+++ b/tools/router-demo/tsconfig.json
@@ -4,7 +4,7 @@
         "allowUnreachableCode": false,
         "declaration": false,
         "experimentalDecorators": true,
-        "lib": ["dom", "es2017"],
+        "lib": ["dom", "es2019"],
         "moduleResolution": "node",
         "module": "esnext",
         "target": "es2017",


### PR DESCRIPTION
- Work around safari crash on delegateFocus by removing all delegateFocus
- Add delegateFocus util to simulate focusing a delegateFocus element
- Off the back of the delegatefocus util, add a focus trap util
- Apply focus trap to modal, popover etc
- bump tsconfig lib for flatmap