### PR TITLE
standardize table keyboard navigation across browsers

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -127,6 +127,7 @@ export namespace Components {
         "rowClass": (
         row: any,
     ) => Record<string, boolean> | string | undefined;
+        "rowTakesFocus"?: boolean;
         "rows": string[];
     }
     interface EsTableDetail {
@@ -153,10 +154,12 @@ export namespace Components {
         "loadNested"?: (key: string, data: any) => Promise<void>;
         "nestedColumns"?: string[];
         "nestedIdentifier": string;
+        "nestedRowTakesFocus"?: boolean;
         "outerIdentifier": string;
         "rowClass": (
         row: any,
     ) => Record<string, boolean> | string | undefined;
+        "rowTakesFocus"?: boolean;
         "rows": string[];
     }
     interface EsToast {
@@ -465,6 +468,7 @@ declare namespace LocalJSX {
         "rowClass"?: (
         row: any,
     ) => Record<string, boolean> | string | undefined;
+        "rowTakesFocus"?: boolean;
         "rows": string[];
     }
     interface EsTableDetail {
@@ -491,12 +495,14 @@ declare namespace LocalJSX {
         "loadNested"?: (key: string, data: any) => Promise<void>;
         "nestedColumns"?: string[];
         "nestedIdentifier"?: string;
+        "nestedRowTakesFocus"?: boolean;
         "onClickRow"?: (event: CustomEvent<any>) => void;
         "onExpansion"?: (event: CustomEvent<{ data: any; key: string }>) => void;
         "outerIdentifier"?: string;
         "rowClass"?: (
         row: any,
     ) => Record<string, boolean> | string | undefined;
+        "rowTakesFocus"?: boolean;
         "rows": string[];
     }
     interface EsToast {

--- a/packages/components/src/components/es-table-nested/es-table-nested.tsx
+++ b/packages/components/src/components/es-table-nested/es-table-nested.tsx
@@ -13,6 +13,7 @@ export class TableNested {
     @Prop() columns?: string[];
     @Prop() rows!: string[];
     @Prop() linkRowTo?: (row: any) => string;
+    @Prop() rowTakesFocus?: boolean;
     @Prop() rowClass: (
         row: any,
     ) => Record<string, boolean> | string | undefined = () => undefined;
@@ -22,6 +23,7 @@ export class TableNested {
     @Prop() getNestedRows?: (key: string) => string[] | undefined;
     @Prop() getNestedCellData?: (key: string) => any;
     @Prop() loadNested?: (key: string, data: any) => Promise<void>;
+    @Prop() nestedRowTakesFocus?: boolean;
     @Prop() canExpand: (key: string, data: any) => boolean = () => true;
 
     @State() expanded: Set<string> = new Set();
@@ -37,6 +39,7 @@ export class TableNested {
             <es-table
                 headless
                 class={'nested'}
+                rowTakesFocus={this.nestedRowTakesFocus ?? this.rowTakesFocus}
                 identifier={this.outerIdentifier}
                 getCellData={this.getNestedCellData ?? this.getCellData}
                 cells={this.cellsWithExpander()}
@@ -51,6 +54,7 @@ export class TableNested {
     render() {
         return (
             <es-table
+                rowTakesFocus={this.rowTakesFocus}
                 identifier={this.outerIdentifier}
                 getCellData={this.getCellData}
                 cells={this.cellsWithExpander()}

--- a/packages/components/src/components/es-table-nested/readme.md
+++ b/packages/components/src/components/es-table-nested/readme.md
@@ -7,21 +7,23 @@
 
 ## Properties
 
-| Property             | Attribute           | Description | Type                                                           | Default           |
-| -------------------- | ------------------- | ----------- | -------------------------------------------------------------- | ----------------- |
-| `canExpand`          | --                  |             | `(key: string, data: any) => boolean`                          | `() => true`      |
-| `cells` _(required)_ | --                  |             | `{ [x: string]: TableCell<any>; }`                             | `undefined`       |
-| `columns`            | --                  |             | `string[] \| undefined`                                        | `undefined`       |
-| `getCellData`        | --                  |             | `((key: string) => any) \| undefined`                          | `undefined`       |
-| `getNestedCellData`  | --                  |             | `((key: string) => any) \| undefined`                          | `undefined`       |
-| `getNestedRows`      | --                  |             | `((key: string) => string[] \| undefined) \| undefined`        | `undefined`       |
-| `linkRowTo`          | --                  |             | `((row: any) => string) \| undefined`                          | `undefined`       |
-| `loadNested`         | --                  |             | `((key: string, data: any) => Promise<void>) \| undefined`     | `undefined`       |
-| `nestedColumns`      | --                  |             | `string[] \| undefined`                                        | `undefined`       |
-| `nestedIdentifier`   | `nested-identifier` |             | `string`                                                       | `'nested-table'`  |
-| `outerIdentifier`    | `outer-identifier`  |             | `string`                                                       | `'table'`         |
-| `rowClass`           | --                  |             | `(row: any) => string \| Record<string, boolean> \| undefined` | `() => undefined` |
-| `rows` _(required)_  | --                  |             | `string[]`                                                     | `undefined`       |
+| Property              | Attribute                | Description | Type                                                           | Default           |
+| --------------------- | ------------------------ | ----------- | -------------------------------------------------------------- | ----------------- |
+| `canExpand`           | --                       |             | `(key: string, data: any) => boolean`                          | `() => true`      |
+| `cells` _(required)_  | --                       |             | `{ [x: string]: TableCell<any>; }`                             | `undefined`       |
+| `columns`             | --                       |             | `string[] \| undefined`                                        | `undefined`       |
+| `getCellData`         | --                       |             | `((key: string) => any) \| undefined`                          | `undefined`       |
+| `getNestedCellData`   | --                       |             | `((key: string) => any) \| undefined`                          | `undefined`       |
+| `getNestedRows`       | --                       |             | `((key: string) => string[] \| undefined) \| undefined`        | `undefined`       |
+| `linkRowTo`           | --                       |             | `((row: any) => string) \| undefined`                          | `undefined`       |
+| `loadNested`          | --                       |             | `((key: string, data: any) => Promise<void>) \| undefined`     | `undefined`       |
+| `nestedColumns`       | --                       |             | `string[] \| undefined`                                        | `undefined`       |
+| `nestedIdentifier`    | `nested-identifier`      |             | `string`                                                       | `'nested-table'`  |
+| `nestedRowTakesFocus` | `nested-row-takes-focus` |             | `boolean \| undefined`                                         | `undefined`       |
+| `outerIdentifier`     | `outer-identifier`       |             | `string`                                                       | `'table'`         |
+| `rowClass`            | --                       |             | `(row: any) => string \| Record<string, boolean> \| undefined` | `() => undefined` |
+| `rowTakesFocus`       | `row-takes-focus`        |             | `boolean \| undefined`                                         | `undefined`       |
+| `rows` _(required)_   | --                       |             | `string[]`                                                     | `undefined`       |
 
 
 ## Events

--- a/packages/components/src/components/es-table/es-table.css
+++ b/packages/components/src/components/es-table/es-table.css
@@ -33,11 +33,17 @@ es-table {
                 &:hover,
                 &:focus,
                 & {
+                    & *[role='cell']:focus-visible::before,
                     & *[role='cell']:first-child::before {
                         transform: translateX(10px);
                         opacity: 1;
                     }
                 }
+            }
+
+            & *[role='cell']:focus-visible::before {
+                transform: translateX(5px);
+                opacity: 0.5;
             }
 
             &:hover,
@@ -124,6 +130,15 @@ es-table {
         background-color: var(--row-color);
         border-top: 1px solid var(--border-top-color);
         border-bottom: 1px solid var(--border-bottom-color);
+
+        &.focusCell {
+            outline: none;
+        }
+
+        &:focus,
+        &:focus ~ *[role='cell'] {
+            color: var(--color-secondary);
+        }
 
         &.borderless {
             border-top: 1px solid transparent;

--- a/packages/components/src/components/es-table/readme.md
+++ b/packages/components/src/components/es-table/readme.md
@@ -7,17 +7,18 @@
 
 ## Properties
 
-| Property             | Attribute    | Description | Type                                                           | Default           |
-| -------------------- | ------------ | ----------- | -------------------------------------------------------------- | ----------------- |
-| `cells` _(required)_ | --           |             | `{ [x: string]: TableCell<any>; }`                             | `undefined`       |
-| `columns`            | --           |             | `string[] \| undefined`                                        | `undefined`       |
-| `getCellData`        | --           |             | `((key: string) => any) \| undefined`                          | `undefined`       |
-| `headless`           | `headless`   |             | `boolean`                                                      | `false`           |
-| `identifier`         | `identifier` |             | `string`                                                       | `'table'`         |
-| `linkRowTo`          | --           |             | `((row: any) => string) \| undefined`                          | `undefined`       |
-| `renderExpansion`    | --           |             | `(key: string) => VNode \| null`                               | `() => null`      |
-| `rowClass`           | --           |             | `(row: any) => string \| Record<string, boolean> \| undefined` | `() => undefined` |
-| `rows` _(required)_  | --           |             | `string[]`                                                     | `undefined`       |
+| Property             | Attribute         | Description | Type                                                           | Default           |
+| -------------------- | ----------------- | ----------- | -------------------------------------------------------------- | ----------------- |
+| `cells` _(required)_ | --                |             | `{ [x: string]: TableCell<any>; }`                             | `undefined`       |
+| `columns`            | --                |             | `string[] \| undefined`                                        | `undefined`       |
+| `getCellData`        | --                |             | `((key: string) => any) \| undefined`                          | `undefined`       |
+| `headless`           | `headless`        |             | `boolean`                                                      | `false`           |
+| `identifier`         | `identifier`      |             | `string`                                                       | `'table'`         |
+| `linkRowTo`          | --                |             | `((row: any) => string) \| undefined`                          | `undefined`       |
+| `renderExpansion`    | --                |             | `(key: string) => VNode \| null`                               | `() => null`      |
+| `rowClass`           | --                |             | `(row: any) => string \| Record<string, boolean> \| undefined` | `() => undefined` |
+| `rowTakesFocus`      | `row-takes-focus` |             | `boolean \| undefined`                                         | `undefined`       |
+| `rows` _(required)_  | --                |             | `string[]`                                                     | `undefined`       |
 
 
 ## Events


### PR DESCRIPTION
- `display: content;` should take focus, but in some browsers it doesnt.
- prevent focus on the rows, and delegate to first cell
- add styling to show focus on row