### PR TITLE
Allow listeners on workingData failed validation

### DIFF
--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -1,9 +1,11 @@
-interface CEV<T extends object, K extends keyof T> {
+interface ChangeEventValue<T extends object, K extends keyof T> {
     name: K;
     value: T[K];
 }
 
-export type FieldChangeEvent<T extends object> = CustomEvent<CEV<T, keyof T>>;
+export type FieldChangeEvent<T extends object> = CustomEvent<
+    ChangeEventValue<T, keyof T>
+>;
 
 export type Severity = 'error' | 'warning' | 'info';
 export type ValidationMessages = Record<Severity, string[]>;
@@ -26,6 +28,8 @@ export interface WorkingData<T extends object> {
     ) => Promise<void>;
     listen: (e: FieldChangeEvent<T>) => void;
     onChange: OnChangeHandler<T>;
+    onValidationFailed: OnValidationFailedHandler<T>;
+    onBeforeFocus: OnBeforeFocusHandler<T>;
     freeze: () => void;
     unfreeze: () => void;
 }
@@ -44,6 +48,22 @@ export interface Connector<T> {
 
 export interface OnChangeHandler<T> {
     <Key extends keyof T>(key: Key, cb: (newValue: T[Key]) => void): () => void;
+}
+
+export type ValidationFailedCallback = (
+    info: { id: string; severity: Severity; message: string },
+    ref?: HTMLElement,
+) => void;
+export interface OnValidationFailedHandler<T> {
+    <Key extends keyof T>(key: Key, cb: ValidationFailedCallback): () => void;
+}
+
+export type BeforeFocusCallback<K> = (
+    key: K,
+    ref: HTMLElement,
+) => boolean | void | Promise<boolean | void>;
+export interface OnBeforeFocusHandler<T> {
+    (cb: BeforeFocusCallback<keyof T>): () => void;
 }
 
 export type WorkingDataOptions<T> = {
@@ -77,6 +97,7 @@ export type Validator<T, U> = (
 export type Message<T, U> = (value: T, data: U) => string;
 
 export interface Validation<T, U> {
+    id?: string;
     validator: Validator<T, U>;
     message: Message<T, U> | string;
     severity?: Severity;

--- a/packages/fields/src/utils/workingData/createStores.ts
+++ b/packages/fields/src/utils/workingData/createStores.ts
@@ -4,6 +4,8 @@ import {
     InternalFieldOptions,
     WorkingDataState,
     ValidationMessages,
+    ValidationFailedCallback,
+    BeforeFocusCallback,
 } from '../../types';
 
 type MessageStore<T> = { [key in keyof T]: ValidationMessages };
@@ -14,6 +16,8 @@ interface Stores<T> {
     state: ObservableMap<WorkingDataState>;
     fields: Map<keyof T, Required<InternalFieldOptions<any, T>>>;
     refs: Map<keyof T, HTMLElement>;
+    validationFailedCallbacks: Map<keyof T, Set<ValidationFailedCallback>>;
+    beforeFocusCallbacks: Set<BeforeFocusCallback<keyof T>>;
 }
 
 export const blankMessages = (): ValidationMessages => ({
@@ -46,5 +50,7 @@ export const createStores = <T>(
         state: createStore<WorkingDataState>(defaultState),
         fields: fields as any,
         refs: new Map(),
+        validationFailedCallbacks: new Map(),
+        beforeFocusCallbacks: new Set(),
     };
 };


### PR DESCRIPTION
- Warn (in dev) and ignore events for unknown fields
- Add callbacks on events within workingdata
  - onValidationFailure
  - onBeforeFocus
  
fixes: #58 