### PR TITLE
Add workflow for deploying documentation to github pages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
 
             - run: git lfs pull
 
-            # Install node
             - name: Setup Node
               uses: actions/setup-node@v1
               with:
                   node-version: '16.x'
+
+            - name: Corepack
+              run: corepack enable
 
             - name: Install
               run: yarn install

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+name: GitHub Pages
+
+on:
+    push:
+        branches:
+            - 'main'
+
+permissions: read-all
+
+jobs:
+    pages:
+        runs-on: ubuntu-latest
+
+        permissions:
+            pages: write
+            id-token: write
+
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Cache git lfs
+              uses: actions/cache@v2
+              with:
+                  path: .yarn/cache
+                  key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+            - run: git lfs pull
+
+            - name: Setup Node
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '16.x'
+
+            - name: Corepack
+              run: corepack enable
+
+            - name: Install
+              run: yarn install
+
+            - name: Build libraries
+              run: yarn build
+
+            - name: Build documentation
+              run: yarn docs
+
+            # Note: The following two steps are temporary and won't be
+            # necessary once actions/deploy-pages is out of beta.
+            - name: Archive documentation
+              run: tar --directory documentation/www/ -cvf artifact.tar .
+
+            - name: Upload artifact
+              uses: actions/upload-artifact@v3
+              with:
+                  name: github-pages
+                  path: ./artifact.tar
+
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v1-beta


### PR DESCRIPTION
Should run whenever we push to main.

Once the repo is made public, we need to follow these steps to enable:
https://github.com/actions/deploy-pages/issues/20#issuecomment-1068207408