### PR TITLE
Allow es-stores stencil subscription to work with multiple stencil instances

### DIFF
--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -1,3 +1,5 @@
+import './utils/initialize';
+
 export { createStore, Store } from './stores/createStore';
 export { createListStore, ListStore } from './stores/createListStore';
 export {

--- a/packages/stores/src/stores/createStore.test.ts
+++ b/packages/stores/src/stores/createStore.test.ts
@@ -1,3 +1,4 @@
+import '../utils/initialize';
 import { createStore } from './createStore';
 
 describe.each<[string, 'reset' | 'dispose']>([

--- a/packages/stores/src/subscriptions/stencil.ts
+++ b/packages/stores/src/subscriptions/stencil.ts
@@ -1,102 +1,34 @@
-import { forceUpdate, getRenderingRef, getElement } from '@stencil/core';
-import { debounce } from '@eventstore-ui/utils';
+import { createInterestedParties } from '../utils/interest';
 import type { Subscription } from '../types';
-
-type Element = any;
 
 const $keys = Symbol('keys');
 
-const allSubscriptions = new Set<Map<string | number | symbol, Set<Element>>>();
-
-const scheduleCleanup = debounce(() => {
-    for (const elementsToUpdate of allSubscriptions) {
-        for (const [key, elements] of elementsToUpdate) {
-            for (const el of Array.from(elements)) {
-                if (getElement(el)?.isConnected) continue;
-                elementsToUpdate.get(key)?.delete(el);
-                if (elementsToUpdate.get(key)?.size === 0) {
-                    elementsToUpdate.delete(key);
-                }
-            }
-        }
-    }
-}, 2_000);
-
-const addToMapSet = <K, V>(map: Map<K, Set<V>>, key: K, value: V) => {
-    if (!map.has(key)) {
-        map.set(key, new Set());
-    }
-
-    map.get(key)!.add(value);
-};
-
 export const stencilSubscription = <T>(): Subscription<T> => {
-    // If we are not in a stencil project, we do nothing.
-    // This function is not really exported by @stencil/core.
-    if (typeof getRenderingRef !== 'function') return {};
-
-    type Key = symbol | keyof T;
-
-    const elementsToUpdate = new Map<Key, Set<Element>>();
-
-    allSubscriptions.add(elementsToUpdate);
-
-    const refreshElements = (key: Key) => {
-        if (!elementsToUpdate.has(key)) return;
-
-        for (const el of Array.from(elementsToUpdate.get(key)!)) {
-            // force update returns false if it fails but is typed wrong
-            const successfullyUpdated = (forceUpdate(el) as unknown) as boolean;
-
-            if (!successfullyUpdated) {
-                elementsToUpdate.get(key)?.delete(el);
-
-                if (elementsToUpdate.get(key)?.size === 0) {
-                    elementsToUpdate.delete(key);
-                }
-            }
-        }
-    };
-
+    const interestedParties = createInterestedParties();
     return {
         dispose: () => {
-            elementsToUpdate.clear();
+            interestedParties.clear();
         },
         get: (propName) => {
-            const el = getRenderingRef();
-
-            if (el) {
-                addToMapSet(elementsToUpdate, propName, el);
-            }
-            scheduleCleanup();
+            interestedParties.registerInterest(propName);
         },
         keys: () => {
-            const el = getRenderingRef();
-            if (el) {
-                addToMapSet(elementsToUpdate, $keys, el);
-            }
-            scheduleCleanup();
+            interestedParties.registerInterest($keys);
         },
         set: (propName) => {
-            refreshElements(propName);
-            scheduleCleanup();
+            interestedParties.inform(propName);
         },
         delete: (propName) => {
-            refreshElements($keys);
+            interestedParties.inform($keys);
             requestAnimationFrame(() => {
-                refreshElements(propName);
+                interestedParties.inform(propName);
             });
-            scheduleCleanup();
         },
         insert: () => {
-            refreshElements($keys);
-            scheduleCleanup();
+            interestedParties.inform($keys);
         },
         reset: () => {
-            elementsToUpdate.forEach((elements) =>
-                elements.forEach(forceUpdate),
-            );
-            scheduleCleanup();
+            interestedParties.informAll();
         },
     };
 };

--- a/packages/stores/src/symbols.ts
+++ b/packages/stores/src/symbols.ts
@@ -1,1 +1,2 @@
 export const $data = Symbol('data');
+export const $interestFinders = Symbol.for('es-interest-finders');

--- a/packages/stores/src/utils/initialize.ts
+++ b/packages/stores/src/utils/initialize.ts
@@ -1,0 +1,25 @@
+import { forceUpdate, getRenderingRef, getElement } from '@stencil/core';
+import { $interestFinders } from '../symbols';
+
+declare global {
+    interface Window {
+        [$interestFinders]: Set<InterestFinder>;
+    }
+}
+
+interface InterestFinder {
+    forceUpdate: (ref: any) => boolean;
+    getRenderingRef: typeof getRenderingRef;
+    getElement: typeof getElement;
+}
+
+window[$interestFinders] = window[$interestFinders] ?? new Set();
+
+if (typeof getRenderingRef === 'function') {
+    window[$interestFinders].add({
+        getRenderingRef,
+        // force update returns boolean if it fails but is typed wrong
+        forceUpdate: forceUpdate as any,
+        getElement,
+    });
+}

--- a/packages/stores/src/utils/interest.ts
+++ b/packages/stores/src/utils/interest.ts
@@ -1,0 +1,85 @@
+import { debounce } from '@eventstore-ui/utils';
+import { $interestFinders } from '../symbols';
+
+interface Interested {
+    update(): boolean;
+    isConnected(): boolean;
+}
+
+const interestFinders = window[$interestFinders];
+
+const allSubscriptions = new Set<
+    Map<string | number | symbol, Set<Interested>>
+>();
+
+class InterestedParties<K> {
+    private interested: Map<K, Set<Interested>> = new Map();
+
+    public registerInterest = (key: K) => {
+        for (const {
+            getRenderingRef,
+            forceUpdate,
+            getElement,
+        } of interestFinders) {
+            const ref = getRenderingRef();
+
+            if (!ref) continue;
+
+            if (!this.interested.has(key)) {
+                this.interested.set(key, new Set());
+            }
+
+            this.interested.get(key)!.add({
+                update: () => forceUpdate(ref),
+                isConnected: () => !!getElement(ref)?.isConnected,
+            });
+        }
+
+        this.scheduleCleanup();
+    };
+
+    public inform = (key: K) => {
+        if (!this.interested.has(key)) return;
+
+        for (const el of this.interested.get(key)!) {
+            const successfullyUpdated = el.update();
+
+            if (!successfullyUpdated) {
+                this.interested.get(key)?.delete(el);
+                if (this.interested.get(key)?.size === 0) {
+                    this.interested.delete(key);
+                }
+            }
+        }
+
+        this.scheduleCleanup();
+    };
+
+    public informAll = () => {
+        for (const key of this.interested.keys()) {
+            this.inform(key);
+        }
+        this.scheduleCleanup();
+    };
+
+    public clear = () => {
+        this.interested.clear();
+        this.scheduleCleanup();
+    };
+
+    private scheduleCleanup = debounce(() => {
+        for (const subscription of allSubscriptions) {
+            for (const [key, interested] of subscription) {
+                for (const el of Array.from(interested)) {
+                    if (el.isConnected()) continue;
+                    subscription.get(key)?.delete(el);
+                    if (subscription.get(key)?.size === 0) {
+                        subscription.delete(key);
+                    }
+                }
+            }
+        }
+    }, 2_000);
+}
+
+export const createInterestedParties = <K>() => new InterestedParties<K>();


### PR DESCRIPTION
Register stencil instances to  inform components of changes regardless of which element was defined with.