### PR TITLE
Add dev mode to stencil libs to allow dev only components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "build": "stencil build --docs",
-        "start": "stencil build --dev --watch --serve",
+        "dev": "stencil build --dev --watch --serve",
         "docs": "run-s \"docs:*\"",
         "docs:stencil": "stencil build --docs-json ../../documentation/generated/components.stencil.json",
         "docs:typedoc": "typedoc --logLevel Error --json ../../documentation/generated/components.typedoc.json",

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.demo.tsx"]
+}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -21,6 +21,5 @@
         "entryPoints": ["./src/index.ts"],
         "exclude": ["./src/components.d.ts"]
     },
-    "include": ["src", "types/jsx.d.ts"],
-    "exclude": ["node_modules"]
+    "include": ["src", "types/jsx.d.ts"]
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -31,7 +31,7 @@
     },
     "scripts": {
         "build": "run-s \"build:*\"",
-        "start": "stencil build --dev --watch --serve --openBrowser=false",
+        "dev": "stencil build --dev --watch --serve",
         "build:utils": "run-p \"utils:*\"",
         "build:workers": "run-p \"workers:*\"",
         "build:stencil": "stencil build --docs",

--- a/packages/editor/tsconfig.build.json
+++ b/packages/editor/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.demo.tsx"]
+}

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -16,6 +16,5 @@
         "jsxFactory": "h",
         "jsxFragmentFactory": "Fragment"
     },
-    "include": ["src"],
-    "exclude": ["node_modules"]
+    "include": ["src"]
 }

--- a/packages/fields/tsconfig.build.json
+++ b/packages/fields/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.demo.tsx"]
+}

--- a/packages/illustrations/package.json
+++ b/packages/illustrations/package.json
@@ -23,7 +23,7 @@
     "scripts": {
         "import": "node ./scripts/import.mjs",
         "build": "stencil build --docs",
-        "start": "stencil build --dev --watch --serve",
+        "dev": "stencil build --dev --watch --serve",
         "docs": "run-s \"docs:*\"",
         "docs:stencil": "stencil build --docs-json ../../documentation/generated/illustrations.stencil.json",
         "docs:typedoc": "typedoc --logLevel Error --json ../../documentation/generated/illustrations.typedoc.json",

--- a/packages/illustrations/tsconfig.build.json
+++ b/packages/illustrations/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.demo.tsx"]
+}

--- a/packages/illustrations/tsconfig.json
+++ b/packages/illustrations/tsconfig.json
@@ -21,6 +21,5 @@
         "entryPoints": ["./src/index.ts"],
         "exclude": ["./src/components.d.ts"]
     },
-    "include": ["src", "types/jsx.d.ts"],
-    "exclude": ["node_modules"]
+    "include": ["src", "types/jsx.d.ts"]
 }

--- a/packages/layout/tsconfig.build.json
+++ b/packages/layout/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["**/*.demo.tsx"]
+}

--- a/packages/layout/tsconfig.json
+++ b/packages/layout/tsconfig.json
@@ -21,6 +21,5 @@
         "entryPoints": ["./src/index.ts"],
         "exclude": ["./src/components.d.ts"]
     },
-    "include": ["src", "types/jsx.d.ts"],
-    "exclude": ["node_modules"]
+    "include": ["src", "types/jsx.d.ts"]
 }

--- a/tools/configs/dev/dev.css
+++ b/tools/configs/dev/dev.css
@@ -1,0 +1,25 @@
+@import url('~@eventstore-ui/layout/css/root.css');
+@import url('~@eventstore-ui/assets/font-face.css');
+
+body {
+    display: block;
+}
+
+body ul.links {
+    list-style: none;
+    padding: 20px;
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+body ul.links li a {
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    border-radius: 12px;
+    color: #435261;
+    border: 2px solid #f6f6f6;
+    padding: 20px;
+}

--- a/tools/configs/dev/devMode.ts
+++ b/tools/configs/dev/devMode.ts
@@ -1,0 +1,101 @@
+import { dirname, join, sep } from 'path';
+import type {
+    BuildCtx,
+    OutputTargetCustom,
+    CompilerCtx,
+    Config as StencilConfig,
+    JsonDocs,
+} from '@stencil/core/internal';
+
+class DevMode implements OutputTargetCustom {
+    public type: 'custom' = 'custom';
+    public name = 'dev-mode';
+
+    async generator(
+        stencilConfig: StencilConfig,
+        compilerCtx: CompilerCtx,
+        buildCtx: BuildCtx,
+        docs: JsonDocs,
+    ) {
+        const timespan = buildCtx.createTimeSpan('dev mode started', true);
+
+        const devComponents = buildCtx.components
+            .filter(({ isCollectionDependency }) => !isCollectionDependency)
+            .filter(({ sourceFilePath }) =>
+                sourceFilePath.endsWith('.demo.tsx'),
+            )
+            .map<[string, string]>(({ tagName }) => [
+                tagName,
+                docs.components.find((c) => c.tag === tagName)?.docs ?? '',
+            ]);
+
+        const filePath = join(stencilConfig.rootDir!, 'www', 'index.html');
+
+        await compilerCtx.fs.writeFile(
+            filePath,
+            buildIndex({
+                name: stencilConfig.fsNamespace ?? 'app',
+                devComponents,
+            }),
+        );
+
+        timespan.finish('generate plugin manifest finished');
+    }
+}
+
+export const devMode = (): DevMode => new DevMode();
+
+interface IndexBuilder {
+    name: string;
+    devComponents: Array<[string, string]>;
+}
+
+const buildIndex = ({ name, devComponents }: IndexBuilder) => `
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>${name}</title>
+        <meta
+            name="Description"
+            content="Welcome to the Stencil App Starter. You can use this starter to build entire apps all with web components using Stencil!"
+        />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+        />
+        <meta name="theme-color" content="#16161d" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta http-equiv="x-ua-compatible" content="IE=Edge" />
+
+        <link href="/build/${name}.css" rel="stylesheet" />
+        <script type="module" src="/build/${name}.esm.js"></script>
+        <script nomodule src="/build/${name}.js"></script>
+
+        <link
+            rel="icon"
+            type="image/x-icon"
+            href="/assets/favicons/favicon.ico"
+        />
+    </head>
+    <body>
+        <ul class="links">
+            ${devComponents
+                .map(
+                    ([name, description]) =>
+                        `<li><a href="${name}"><b>${name}</b><span>${description}</span></a></li>`,
+                )
+                .join(' ')}
+        </ul>
+        <script>
+        const tagname = document.location.pathname.replace('/', '');
+
+        if (tagname != '') {
+            const links = document.querySelector("ul.links").remove();
+            const el = document.createElement(tagname);
+            document.body.append(el);
+        }
+        </script>
+    </body>
+</html>
+`;


### PR DESCRIPTION
- Exclude `*.demo.tsx` files from production builds
- Add dev mode generator to create basic index / display for `*.demo.tsx` files.

![image](https://user-images.githubusercontent.com/11861797/191795375-97080cc9-89c5-4e84-9b84-ec18ae1f8e9d.png)

- Add (or amend) `yarn dev` script to run dev mode  with serving

fixes: #134 