### PR TITLE
`<es-loading-text />`

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -198,6 +198,16 @@ export namespace Components {
          */
         "spinEnd": () => Promise<void>;
     }
+    interface EsLoadingText {
+        /**
+          * The expected loaded text length.
+         */
+        "expectedLength": number;
+        /**
+          * Adds a random number of chars (up to the passed amount)
+         */
+        "variance"?: number;
+    }
     interface EsModal {
         /**
           * If the modal should have a footer.
@@ -663,6 +673,12 @@ declare global {
         prototype: HTMLEsIconElement;
         new (): HTMLEsIconElement;
     };
+    interface HTMLEsLoadingTextElement extends Components.EsLoadingText, HTMLStencilElement {
+    }
+    var HTMLEsLoadingTextElement: {
+        prototype: HTMLEsLoadingTextElement;
+        new (): HTMLEsLoadingTextElement;
+    };
     interface HTMLEsModalElement extends Components.EsModal, HTMLStencilElement {
     }
     var HTMLEsModalElement: {
@@ -782,6 +798,7 @@ declare global {
         "es-corner-banner": HTMLEsCornerBannerElement;
         "es-counter": HTMLEsCounterElement;
         "es-icon": HTMLEsIconElement;
+        "es-loading-text": HTMLEsLoadingTextElement;
         "es-modal": HTMLEsModalElement;
         "es-pagination": HTMLEsPaginationElement;
         "es-popover": HTMLEsPopoverElement;
@@ -969,6 +986,16 @@ declare namespace LocalJSX {
           * When spinning, should it spin clockwise or anticlockwise.
          */
         "spinDirection"?: 'clockwise' | 'antiClockwise';
+    }
+    interface EsLoadingText {
+        /**
+          * The expected loaded text length.
+         */
+        "expectedLength": number;
+        /**
+          * Adds a random number of chars (up to the passed amount)
+         */
+        "variance"?: number;
     }
     interface EsModal {
         /**
@@ -1376,6 +1403,7 @@ declare namespace LocalJSX {
         "es-corner-banner": EsCornerBanner;
         "es-counter": EsCounter;
         "es-icon": EsIcon;
+        "es-loading-text": EsLoadingText;
         "es-modal": EsModal;
         "es-pagination": EsPagination;
         "es-popover": EsPopover;
@@ -1410,6 +1438,7 @@ declare module "@stencil/core" {
             "es-corner-banner": LocalJSX.EsCornerBanner & JSXBase.HTMLAttributes<HTMLEsCornerBannerElement>;
             "es-counter": LocalJSX.EsCounter & JSXBase.HTMLAttributes<HTMLEsCounterElement>;
             "es-icon": LocalJSX.EsIcon & JSXBase.HTMLAttributes<HTMLEsIconElement>;
+            "es-loading-text": LocalJSX.EsLoadingText & JSXBase.HTMLAttributes<HTMLEsLoadingTextElement>;
             "es-modal": LocalJSX.EsModal & JSXBase.HTMLAttributes<HTMLEsModalElement>;
             "es-pagination": LocalJSX.EsPagination & JSXBase.HTMLAttributes<HTMLEsPaginationElement>;
             "es-popover": LocalJSX.EsPopover & JSXBase.HTMLAttributes<HTMLEsPopoverElement>;

--- a/packages/components/src/components/es-loading-text/LoadingText.tsx
+++ b/packages/components/src/components/es-loading-text/LoadingText.tsx
@@ -1,0 +1,25 @@
+import { h, FunctionalComponent } from '@stencil/core';
+
+export interface LoadingTextProps {
+    /** The expected loaded text length. */
+    expectedLength: number;
+    /** Adds a random number of chars (up to the passed amount) */
+    variance?: number;
+    /** Auto wraps the passed string in an es-copy */
+    copy?: boolean;
+}
+
+/**
+ * Displays an es-loading-text if the passed child is empty.
+ */
+export const LoadingText: FunctionalComponent<LoadingTextProps> = (
+    { copy = false, ...props },
+    children,
+) =>
+    children.every((t) => t == null) ? (
+        <es-loading-text {...props} />
+    ) : copy ? (
+        <es-copy>{children}</es-copy>
+    ) : (
+        children
+    );

--- a/packages/components/src/components/es-loading-text/es-loading-text.css
+++ b/packages/components/src/components/es-loading-text/es-loading-text.css
@@ -1,0 +1,9 @@
+:host {
+    display: inline-block;
+    background-color: var(--color-text);
+    opacity: 0.1;
+    border-radius: 12px;
+    white-space: pre;
+    color: transparent;
+    user-select: none;
+}

--- a/packages/components/src/components/es-loading-text/es-loading-text.demo.tsx
+++ b/packages/components/src/components/es-loading-text/es-loading-text.demo.tsx
@@ -1,0 +1,63 @@
+import { Component, h, Host, State } from '@stencil/core';
+import { LoadingText } from './LoadingText';
+
+/**
+ * es-loading-text & LoadingText demo
+ */
+@Component({
+    tag: 'es-loading-text-demo',
+    shadow: true,
+})
+export class LoadingTextDemo {
+    @State() texts: string[] = [];
+
+    componentDidLoad() {
+        setTimeout(() => {
+            this.texts = [
+                'hello',
+                'there',
+                'this',
+                'is',
+                'some',
+                'loaded',
+                'text',
+                'it has loaded!',
+            ];
+        }, 5000);
+    }
+
+    render() {
+        return (
+            <Host style={{ display: 'block', padding: '20px' }}>
+                <h1>{'Basic usage'}</h1>
+                <es-loading-text expectedLength={12} />
+                <h1>{'Variance'}</h1>
+                <ul>
+                    {Array.from({ length: 8 }, () => (
+                        <li style={{ padding: '4px' }}>
+                            <es-loading-text
+                                expectedLength={12}
+                                variance={10}
+                            />
+                        </li>
+                    ))}
+                </ul>
+
+                <h1>{'<LoadingText />'}</h1>
+                <ul>
+                    {Array.from({ length: 8 }, (_, i) => (
+                        <li style={{ padding: '4px' }}>
+                            <LoadingText
+                                copy={i === 0}
+                                expectedLength={12}
+                                variance={10}
+                            >
+                                {this.texts[i]}
+                            </LoadingText>
+                        </li>
+                    ))}
+                </ul>
+            </Host>
+        );
+    }
+}

--- a/packages/components/src/components/es-loading-text/es-loading-text.tsx
+++ b/packages/components/src/components/es-loading-text/es-loading-text.tsx
@@ -1,0 +1,23 @@
+import { Component, h, Host, Prop } from '@stencil/core';
+
+/**
+ * Displays a grey block to placehold loading text.
+ */
+@Component({
+    tag: 'es-loading-text',
+    styleUrl: 'es-loading-text.css',
+    shadow: true,
+})
+export class EsLoadingText {
+    /** The expected loaded text length. */
+    @Prop() expectedLength!: number;
+    /** Adds a random number of chars (up to the passed amount) */
+    @Prop() variance?: number;
+
+    render() {
+        const renderedLength = this.variance
+            ? Math.floor(Math.random() * this.variance) + this.expectedLength
+            : this.expectedLength;
+        return <Host role={'presentation'}>{' '.repeat(renderedLength)}</Host>;
+    }
+}

--- a/packages/components/src/components/es-loading-text/readme.md
+++ b/packages/components/src/components/es-loading-text/readme.md
@@ -1,0 +1,35 @@
+# es-loading-text
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Usage
+
+### Example
+
+```tsx
+export default () => (
+    <>
+        <es-loading-text expectedLength={12} />
+        <es-loading-text expectedLength={12} variance={14} />
+        <es-loading-text expectedLength={12} variance={14} />
+        <es-loading-text expectedLength={12} variance={14} />
+    </>
+);
+```
+
+
+
+## Properties
+
+| Property                      | Attribute         | Description                                             | Type                  | Default     |
+| ----------------------------- | ----------------- | ------------------------------------------------------- | --------------------- | ----------- |
+| `expectedLength` _(required)_ | `expected-length` | The expected loaded text length.                        | `number`              | `undefined` |
+| `variance`                    | `variance`        | Adds a random number of chars (up to the passed amount) | `number \| undefined` | `undefined` |
+
+
+----------------------------------------------
+
+

--- a/packages/components/src/components/es-loading-text/usage/example.md
+++ b/packages/components/src/components/es-loading-text/usage/example.md
@@ -1,0 +1,10 @@
+```tsx
+export default () => (
+    <>
+        <es-loading-text expectedLength={12} />
+        <es-loading-text expectedLength={12} variance={14} />
+        <es-loading-text expectedLength={12} variance={14} />
+        <es-loading-text expectedLength={12} variance={14} />
+    </>
+);
+```

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,6 +5,7 @@ export type { TableCells, TableCell } from './components/es-table/types';
 export type { WizardPage } from './components/es-wizard/types';
 export type { Tab } from './components/es-tabs/types';
 export type { ToastOptions } from './components/toast/types';
+export type { PageChangeEventType } from './components/es-pagination/types';
 export type {
     IconDescription,
     NamespacedIcon,
@@ -12,6 +13,9 @@ export type {
 
 export { toast } from './utils/toast';
 export { iconStore } from './utils/iconStore';
-export { requestClose } from './components/es-popover/utils/requestClose';
-export { PageChangeEventType } from './components/es-pagination/types';
 export { ICON_NAMESPACE as ES_COMPONENTS_ICON_NAMESPACE } from './icons/namespace';
+export { requestClose } from './components/es-popover/utils/requestClose';
+export {
+    LoadingText,
+    LoadingTextProps,
+} from './components/es-loading-text/LoadingText';

--- a/packages/components/src/init.ts
+++ b/packages/components/src/init.ts
@@ -1,1 +1,2 @@
+import '@eventstore-ui/theme';
 import './icons';


### PR DESCRIPTION
Move `stbr-loading-text` to es-components.

![image](https://user-images.githubusercontent.com/11861797/192828180-f10372d4-efb4-435b-8ad1-f4f77ab2a530.png)

fixes: #226 
