### PR TITLE
fix component docs generation

### DIFF
--- a/tools/configs/stencil.ts
+++ b/tools/configs/stencil.ts
@@ -18,7 +18,7 @@ interface PackageConfig extends Partial<Config> {
 }
 
 interface Config extends StencilConfig {
-    buildDocs: boolean;
+    buildDocs?: boolean;
 }
 
 export const packageConfig = ({
@@ -65,7 +65,7 @@ export const packageConfig = ({
         !flags.dev && existsSync('./tsconfig.build.json')
             ? './tsconfig.build.json'
             : './tsconfig.json',
-    buildDocs: flags.docs || flags.dev || false,
+    buildDocs: flags.dev || undefined,
     plugins: [
         postcss({
             plugins: [


### PR DESCRIPTION
Docs generation was being disabled on `--docs-json`, changed to only enable on dev, not take full control.