### PR TITLE
Allow router actions to work across stencil instances

### DIFF
--- a/packages/router/src/utils/getInternalRouter.ts
+++ b/packages/router/src/utils/getInternalRouter.ts
@@ -1,5 +1,5 @@
-import { forceUpdate, getRenderingRef } from '@stencil/core';
+import { forceUpdate, getElement, getRenderingRef } from '@stencil/core';
 import { INTERNAL_ROUTER } from './globals';
 
 export const getInternalRouter = () =>
-    window[INTERNAL_ROUTER].with(getRenderingRef, forceUpdate);
+    window[INTERNAL_ROUTER].with(getRenderingRef, forceUpdate, getElement);

--- a/packages/router/src/utils/router.ts
+++ b/packages/router/src/utils/router.ts
@@ -1,4 +1,4 @@
-import { forceUpdate, getRenderingRef } from '@stencil/core';
+import { forceUpdate, getElement, getRenderingRef } from '@stencil/core';
 import type {
     RouterHistory,
     LocationSegments,
@@ -15,7 +15,11 @@ export class PublicRouter implements Router {
             this.init();
         }
 
-        return window[INTERNAL_ROUTER].with(getRenderingRef, forceUpdate);
+        return window[INTERNAL_ROUTER].with(
+            getRenderingRef,
+            forceUpdate,
+            getElement,
+        );
     }
 
     public init = (options?: RouterOptions) => {


### PR DESCRIPTION
- Add getElement to passed stencil context utils
- Look for rendering element across stencil instances