### PR TITLE
Virtualized table timing bugs

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -518,7 +518,7 @@ export namespace Components {
         /**
           * Groups rows into blocks
          */
-        "blockSize": bigint;
+        "blockSize": number;
         /**
           * A record of table cell definitions.
          */
@@ -530,11 +530,11 @@ export namespace Components {
         /**
           * Sync function for extracting the data from the row. By default, it assumes you passed an array of data as your columns.
          */
-        "getCellData": (key: string, index: bigint) => any;
+        "getCellData": (key: string, index: number) => any;
         /**
           * Sync function for converting an index into a key
          */
-        "getKeyFromIndex": (index: bigint) => string;
+        "getKeyFromIndex": (index: number) => string;
         /**
           * The height (in pixels) of the header
          */
@@ -550,7 +550,7 @@ export namespace Components {
         /**
           * Jump to the passed row, with smooth scroll and highlight, if specified.
          */
-        "jumpToRow": (index: bigint, { highlight, smooth }?: Partial<JumpOptions>) => Promise<void>;
+        "jumpToRow": (index: number, { highlight, smooth }?: Partial<JumpOptions>) => Promise<void>;
         /**
           * A function to calculate a href from the cell data.
          */
@@ -558,7 +558,7 @@ export namespace Components {
         /**
           * The size of the grid rows before starting a reflow
          */
-        "reflowSize": bigint;
+        "reflowSize": number;
         /**
           * Display in a row after the last row
          */
@@ -573,12 +573,12 @@ export namespace Components {
         "rowClass": (
         row: any,
         key: string,
-        index: bigint,
+        index: number,
     ) => Record<string, boolean> | string | undefined;
         /**
           * The total number of rows
          */
-        "rowCount": bigint;
+        "rowCount": number;
         /**
           * The height (in pixels) of the row
          */
@@ -602,7 +602,7 @@ export namespace Components {
         /**
           * The size of the window to render
          */
-        "windowSize": bigint;
+        "windowSize": number;
     }
     interface EsTabs {
         /**
@@ -1471,7 +1471,7 @@ declare namespace LocalJSX {
         /**
           * Groups rows into blocks
          */
-        "blockSize"?: bigint;
+        "blockSize"?: number;
         /**
           * A record of table cell definitions.
          */
@@ -1483,11 +1483,11 @@ declare namespace LocalJSX {
         /**
           * Sync function for extracting the data from the row. By default, it assumes you passed an array of data as your columns.
          */
-        "getCellData": (key: string, index: bigint) => any;
+        "getCellData": (key: string, index: number) => any;
         /**
           * Sync function for converting an index into a key
          */
-        "getKeyFromIndex"?: (index: bigint) => string;
+        "getKeyFromIndex"?: (index: number) => string;
         /**
           * The height (in pixels) of the header
          */
@@ -1513,21 +1513,21 @@ declare namespace LocalJSX {
          */
         "onClickSort"?: (event: EsTableVirtualizedCustomEvent<string>) => void;
         /**
-          * Triggered when the first window is scrolled to
+          * Triggered when the first block is rendered
          */
-        "onFirstWindow"?: (event: EsTableVirtualizedCustomEvent<void>) => void;
+        "onFirstBlock"?: (event: EsTableVirtualizedCustomEvent<void>) => void;
         /**
-          * Triggered when the last window is scrolled to
+          * Triggered when the last block is rendered
          */
-        "onLastWindow"?: (event: EsTableVirtualizedCustomEvent<void>) => void;
+        "onLastBlock"?: (event: EsTableVirtualizedCustomEvent<void>) => void;
         /**
-          * Triggered when a window is rendered
+          * Triggered when a block is rendered
          */
-        "onLoadWindow"?: (event: EsTableVirtualizedCustomEvent<LoadWindow>) => void;
+        "onLoadBlock"?: (event: EsTableVirtualizedCustomEvent<LoadWindow>) => void;
         /**
           * The size of the grid rows before starting a reflow
          */
-        "reflowSize"?: bigint;
+        "reflowSize"?: number;
         /**
           * Display in a row after the last row
          */
@@ -1542,12 +1542,12 @@ declare namespace LocalJSX {
         "rowClass"?: (
         row: any,
         key: string,
-        index: bigint,
+        index: number,
     ) => Record<string, boolean> | string | undefined;
         /**
           * The total number of rows
          */
-        "rowCount": bigint;
+        "rowCount": number;
         /**
           * The height (in pixels) of the row
          */
@@ -1571,7 +1571,7 @@ declare namespace LocalJSX {
         /**
           * The size of the window to render
          */
-        "windowSize"?: bigint;
+        "windowSize"?: number;
     }
     interface EsTabs {
         /**

--- a/packages/components/src/components/tables/demos/table-variants.demo.tsx
+++ b/packages/components/src/components/tables/demos/table-variants.demo.tsx
@@ -26,7 +26,7 @@ export class TableVariant {
             return (
                 <es-table-virtualized
                     cells={this.cells}
-                    rowCount={4n}
+                    rowCount={4}
                     getCellData={() => 'hello'}
                     onClickRow={() => (this.mode = 'detail')}
                     columns={[

--- a/packages/components/src/components/tables/demos/table-virtualized-grouped.demo.tsx
+++ b/packages/components/src/components/tables/demos/table-virtualized-grouped.demo.tsx
@@ -52,7 +52,7 @@ export class Demo {
                     stickyHeader
                     ref={this.captureTable}
                     cells={this.cells}
-                    rowCount={1_000_000n}
+                    rowCount={1_000_000}
                     getCellData={this.getCellData}
                     rowClass={this.rowClass}
                     sort={this.sort}
@@ -95,8 +95,8 @@ export class Demo {
         selected: row?.name === this.active,
     });
 
-    private getCellData = (key: string, index: bigint): DummyData => ({
-        amount: Number(index),
+    private getCellData = (key: string, index: number): DummyData => ({
+        amount: index,
         name: `row-${key}`,
         value: 'something here',
     });
@@ -136,7 +136,7 @@ export class Demo {
 
     private jumpToRandom = () => {
         if (!this.table) return;
-        const index = BigInt(Math.floor(Math.random() * 1_000_000));
+        const index = Math.floor(Math.random() * 1_000_000);
         this.table.jumpToRow(index, { smooth: 'auto', highlight: true });
     };
 }

--- a/packages/components/src/components/tables/demos/table-virtualized.demo.tsx
+++ b/packages/components/src/components/tables/demos/table-virtualized.demo.tsx
@@ -4,7 +4,7 @@ import type { TableCells } from '../types';
 interface DummyData {
     name: string;
     value: string;
-    amount: bigint;
+    amount: number;
 }
 
 /** Basic es-table demo. */
@@ -20,7 +20,7 @@ export class LoadingTextDemo {
                 <es-table-virtualized
                     stickyHeader
                     cells={this.cells}
-                    rowCount={1_000_000n}
+                    rowCount={1_000_000}
                     getCellData={this.getCellData}
                     ref={this.captureTable}
                 />
@@ -46,7 +46,7 @@ export class LoadingTextDemo {
         },
     };
 
-    private getCellData = (key: string, index: bigint): DummyData => ({
+    private getCellData = (key: string, index: number): DummyData => ({
         amount: index,
         name: `row-${key}`,
         value: 'something here',
@@ -59,7 +59,7 @@ export class LoadingTextDemo {
 
     private jumpToRandom = () => {
         if (!this.table) return;
-        const index = BigInt(Math.floor(Math.random() * 1_000_000));
+        const index = Math.floor(Math.random() * 1_000_000);
         this.table.jumpToRow(index, { smooth: 'auto', highlight: true });
     };
 }

--- a/packages/components/src/components/tables/es-table-virtualized/readme.md
+++ b/packages/components/src/components/tables/es-table-virtualized/readme.md
@@ -11,42 +11,42 @@
 | -------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------- |
 | `afterHeight`              | `after-height`    | The height (in pixels) of the after                                                                                     | `number`                                                                                   | `0`                   |
 | `beforeHeight`             | `before-height`   | The height (in pixels) of the before                                                                                    | `number`                                                                                   | `0`                   |
-| `blockSize`                | --                | Groups rows into blocks                                                                                                 | `bigint`                                                                                   | `10n`                 |
+| `blockSize`                | `block-size`      | Groups rows into blocks                                                                                                 | `number`                                                                                   | `10`                  |
 | `cells` _(required)_       | --                | A record of table cell definitions.                                                                                     | `{ [x: string]: TableCell<any>; }`                                                         | `undefined`           |
 | `columns`                  | --                | The order and keys of the cells to be rendered. If omitted, all cells will be rendered.                                 | `string[] \| undefined`                                                                    | `undefined`           |
-| `getCellData` _(required)_ | --                | Sync function for extracting the data from the row. By default, it assumes you passed an array of data as your columns. | `(key: string, index: bigint) => any`                                                      | `undefined`           |
-| `getKeyFromIndex`          | --                | Sync function for converting an index into a key                                                                        | `(index: bigint) => string`                                                                | `(i) => `${i}``       |
+| `getCellData` _(required)_ | --                | Sync function for extracting the data from the row. By default, it assumes you passed an array of data as your columns. | `(key: string, index: number) => any`                                                      | `undefined`           |
+| `getKeyFromIndex`          | --                | Sync function for converting an index into a key                                                                        | `(index: number) => string`                                                                | `(i) => `${i}``       |
 | `headerHeight`             | `header-height`   | The height (in pixels) of the header                                                                                    | `number`                                                                                   | `52`                  |
 | `headless`                 | `headless`        | Do not render header.                                                                                                   | `boolean`                                                                                  | `false`               |
 | `identifier`               | `identifier`      | Passed to cell renderer as `parent`.                                                                                    | `string`                                                                                   | `'table-virtualized'` |
 | `linkRowTo`                | --                | A function to calculate a href from the cell data.                                                                      | `((row: any) => string) \| undefined`                                                      | `undefined`           |
-| `reflowSize`               | --                | The size of the grid rows before starting a reflow                                                                      | `bigint`                                                                                   | `1000n`               |
+| `reflowSize`               | `reflow-size`     | The size of the grid rows before starting a reflow                                                                      | `number`                                                                                   | `1000`                |
 | `renderAfter`              | --                | Display in a row after the last row                                                                                     | `() => VNode \| null`                                                                      | `() => null`          |
 | `renderBefore`             | --                | Display in a row before the first row                                                                                   | `() => VNode \| null`                                                                      | `() => null`          |
-| `rowClass`                 | --                | A function to calculate the class or classes of the row from the cellData.                                              | `(row: any, key: string, index: bigint) => string \| Record<string, boolean> \| undefined` | `() => undefined`     |
-| `rowCount` _(required)_    | --                | The total number of rows                                                                                                | `bigint`                                                                                   | `undefined`           |
+| `rowClass`                 | --                | A function to calculate the class or classes of the row from the cellData.                                              | `(row: any, key: string, index: number) => string \| Record<string, boolean> \| undefined` | `() => undefined`     |
+| `rowCount` _(required)_    | `row-count`       | The total number of rows                                                                                                | `number`                                                                                   | `undefined`           |
 | `rowHeight`                | `row-height`      | The height (in pixels) of the row                                                                                       | `number`                                                                                   | `50`                  |
 | `rowTakesFocus`            | `row-takes-focus` | If rows should be allowed to take focus                                                                                 | `boolean \| undefined`                                                                     | `undefined`           |
 | `scrollLock`               | `scroll-lock`     | If the table should lock scroll on appending events                                                                     | `boolean \| undefined`                                                                     | `undefined`           |
 | `sort`                     | --                | How the table is sorted                                                                                                 | `[key: string, order: SortOrder] \| undefined`                                             | `undefined`           |
 | `stickyHeader`             | `sticky-header`   | Header sticks to scroll parent.                                                                                         | `boolean`                                                                                  | `true`                |
-| `windowSize`               | --                | The size of the window to render                                                                                        | `bigint`                                                                                   | `100n`                |
+| `windowSize`               | `window-size`     | The size of the window to render                                                                                        | `number`                                                                                   | `100`                 |
 
 
 ## Events
 
-| Event         | Description                                                                     | Type                         |
-| ------------- | ------------------------------------------------------------------------------- | ---------------------------- |
-| `clickRow`    | Triggered whenever a row is clicked. The `detail` is the item in the row array. | `CustomEvent<ClickRow<any>>` |
-| `clickSort`   | Triggered whenever a sortable header is clicked                                 | `CustomEvent<string>`        |
-| `firstWindow` | Triggered when the first window is scrolled to                                  | `CustomEvent<void>`          |
-| `lastWindow`  | Triggered when the last window is scrolled to                                   | `CustomEvent<void>`          |
-| `loadWindow`  | Triggered when a window is rendered                                             | `CustomEvent<LoadWindow>`    |
+| Event        | Description                                                                     | Type                         |
+| ------------ | ------------------------------------------------------------------------------- | ---------------------------- |
+| `clickRow`   | Triggered whenever a row is clicked. The `detail` is the item in the row array. | `CustomEvent<ClickRow<any>>` |
+| `clickSort`  | Triggered whenever a sortable header is clicked                                 | `CustomEvent<string>`        |
+| `firstBlock` | Triggered when the first block is rendered                                      | `CustomEvent<void>`          |
+| `lastBlock`  | Triggered when the last block is rendered                                       | `CustomEvent<void>`          |
+| `loadBlock`  | Triggered when a block is rendered                                              | `CustomEvent<LoadWindow>`    |
 
 
 ## Methods
 
-### `jumpToRow(index: bigint, { highlight, smooth }?: Partial<JumpOptions>) => Promise<void>`
+### `jumpToRow(index: number, { highlight, smooth }?: Partial<JumpOptions>) => Promise<void>`
 
 Jump to the passed row, with smooth scroll and highlight, if specified.
 

--- a/packages/components/src/components/tables/es-table/es-table.tsx
+++ b/packages/components/src/components/tables/es-table/es-table.tsx
@@ -94,7 +94,7 @@ export class Table {
                     key={key}
                     class={this.rowClass(data)}
                     onClick={this.emitRowClick({
-                        index: BigInt(index),
+                        index,
                         key,
                         data,
                     })}
@@ -112,7 +112,7 @@ export class Table {
                 key={key}
                 class={this.rowClass(data)}
                 onClick={this.emitRowClick({
-                    index: BigInt(index),
+                    index,
                     key,
                     data,
                 })}
@@ -138,7 +138,7 @@ export class Table {
                         onKeyDown={
                             focusCell
                                 ? this.focusCellKeyPress({
-                                      index: BigInt(index),
+                                      index,
                                       key,
                                       data,
                                   })

--- a/packages/components/src/components/tables/types.ts
+++ b/packages/components/src/components/tables/types.ts
@@ -79,11 +79,11 @@ export interface JumpOptions {
 /** How the table should jump to a row.  */
 export interface LoadWindow {
     /** The first index of the window */
-    from: bigint;
+    from: number;
     /** The last index of the window */
-    to: bigint;
+    to: number;
     /** The number of rows in the window */
-    count: bigint;
+    count: number;
 }
 
 /** An event emitted when a window is loaded. */
@@ -92,7 +92,7 @@ export type LoadWindowEvent = CustomEvent<LoadWindow>;
 /** Information on the row which was clicked. */
 export interface ClickRow<T = any> {
     /** The index of the row that was clicked. */
-    index: bigint;
+    index: number;
     /** The key of the row that was clicked. */
     key: string;
     /** The data (if available) of the row that was clicked. */


### PR DESCRIPTION
- Simplify internal maths by removing bigints
- Wait for table to be rendered before reading scroll heights
- Rename window events to be more accurate