### PR TITLE
Support `baseURL` with `locationSegments`

### DIFF
--- a/packages/router/src/components/Redirect.tsx
+++ b/packages/router/src/components/Redirect.tsx
@@ -22,7 +22,7 @@ export const Redirect: FunctionalComponent<RedirectProps> = (
     const router = getInternalRouter();
     return createCullableNode(
         router.action(() => {
-            router.redirect(props.url);
+            router.replace(props.url);
         }),
         utils,
     );

--- a/packages/router/src/utils/router.ts
+++ b/packages/router/src/utils/router.ts
@@ -53,10 +53,38 @@ export class PublicRouter implements Router {
         return this.internal.fillPath(path, parameters);
     };
 
-    public getUrl = (url: string): string => {
+    public getUrl(url: LocationSegments): LocationSegments;
+    public getUrl(url: string): string;
+    public getUrl(url: string | LocationSegments): typeof url;
+    public getUrl(url: string | LocationSegments): typeof url {
         this.internal.updateInterestedParties();
         return this.internal.getUrl(url);
-    };
+    }
+
+    /** Push a location (navigate) to a path or location. `path` has baseUrl added. */
+    public get push() {
+        return this.internal.push;
+    }
+
+    /** Replace the current location with a path or location. `path` has baseUrl added. */
+    public get replace() {
+        return this.internal.replace;
+    }
+
+    /** Move back one page in the session history. It has the same effect as calling go(-1). If there is no previous page, this method call does nothing. */
+    public get goBack() {
+        return this.internal.goBack;
+    }
+
+    /** Move forward one page in the session history. It has the same effect as calling go(1). If there is no next page, this method call does nothing. */
+    public get goForward() {
+        return this.internal.goForward;
+    }
+
+    /** Load a specific page from the session history. You can use it to move forwards and backwards through the history depending on the value of a parameter. */
+    public get go() {
+        return this.internal.go;
+    }
 }
 
 export const router = new PublicRouter();


### PR DESCRIPTION
- Add support for `LocationSegments` in `getUrl`
- Give access to major history actions in router, with baseUrl filling

fixes #246 