### PR TITLE
remove docs package redirect

### DIFF
--- a/documentation/src/screens/package/package.tsx
+++ b/documentation/src/screens/package/package.tsx
@@ -1,4 +1,4 @@
-import { Redirect, Route, Switch } from '@eventstore-ui/router';
+import { Route, Switch } from '@eventstore-ui/router';
 import { Component, h, Prop } from '@stencil/core';
 import { Host, Watch } from '@stencil/core/internal';
 import { sitemap } from 'sitemap';
@@ -189,9 +189,6 @@ export class DocsPackage {
                             <docs-type-docs lib={lib} doc={doc} />
                         </Route>
                     ))}
-                    <Route>
-                        <Redirect url={`/${this.slug}`} />
-                    </Route>
                 </Switch>
             </Host>
         );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "docs:generate": "yarn workspaces foreach -vpi --topological-dev --no-private run docs",
         "docs:build": "yarn workspace @eventstore-ui/docs run build",
         "docs:dev": "yarn workspace @eventstore-ui/docs run dev",
-        "serve-docs": "yarn workspace @eventstore-ui/docs serve",
+        "docs:serve": "yarn workspace @eventstore-ui/docs serve",
         "test": "yarn workspaces foreach -v --exclude @eventstore-ui/docs run test",
         "lint": "yarn workspaces foreach -v run lint",
         "bump": "yarn workspaces foreach --no-private version"


### PR DESCRIPTION
Docs on github pages redirect to the package root, but this doesnt happen locally. Removing the redirect to see if this avoids the problem.