### PR TITLE
Fix external links

### DIFF
--- a/packages/components/src/components/buttons/es-button-link/es-button-link.tsx
+++ b/packages/components/src/components/buttons/es-button-link/es-button-link.tsx
@@ -46,7 +46,8 @@ export class ButtonLink {
             <Host high-contrast={theme.isHighContrast()} dark={theme.isDark()}>
                 <Link
                     url={this.url}
-                    forceRefresh={this.external || this.forceRefresh}
+                    forceRefresh={this.forceRefresh}
+                    external={this.external}
                     class={this.anchorClass}
                     role={this.anchorRole}
                     title={this.anchorTitle}

--- a/packages/components/src/components/buttons/es-button-link/readme.md
+++ b/packages/components/src/components/buttons/es-button-link/readme.md
@@ -17,27 +17,24 @@ export default () =>
         (variant) => (
             <>
                 <es-button-link
-                    forceRefresh
+                    external
                     variant={variant}
-                    target={'_blank'}
                     url={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
                 >
                     {`${variant} variant`}
                     <es-icon icon={randomIcon()} slot={'after'} />
                 </es-button-link>
                 <es-button-link
-                    forceRefresh
+                    external
                     variant={variant}
-                    target={'_blank'}
                     url={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
                 >
                     <es-icon icon={randomIcon()} size={22} />
                 </es-button-link>
                 <es-button-link
                     disabled
-                    forceRefresh
+                    external
                     variant={variant}
-                    target={'_blank'}
                     url={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
                 >
                     {`${variant} (disabled)`}

--- a/packages/components/src/components/buttons/es-button-link/usage/example.md
+++ b/packages/components/src/components/buttons/es-button-link/usage/example.md
@@ -6,27 +6,24 @@ export default () =>
         (variant) => (
             <>
                 <es-button-link
-                    forceRefresh
+                    external
                     variant={variant}
-                    target={'_blank'}
                     url={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
                 >
                     {`${variant} variant`}
                     <es-icon icon={randomIcon()} slot={'after'} />
                 </es-button-link>
                 <es-button-link
-                    forceRefresh
+                    external
                     variant={variant}
-                    target={'_blank'}
                     url={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
                 >
                     <es-icon icon={randomIcon()} size={22} />
                 </es-button-link>
                 <es-button-link
                     disabled
-                    forceRefresh
+                    external
                     variant={variant}
-                    target={'_blank'}
                     url={'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}
                 >
                     {`${variant} (disabled)`}

--- a/packages/router/src/components/Link.tsx
+++ b/packages/router/src/components/Link.tsx
@@ -15,6 +15,8 @@ export interface LinkProps {
     strict?: boolean;
     /** If the Link should break out of the router, and force a page load.  */
     forceRefresh?: boolean;
+    /** If the Link is external. No baseUrl applied.  */
+    external?: boolean;
     /** If the windows scroll position should be set to 0,0 */
     updateScroll?: boolean;
 
@@ -44,6 +46,7 @@ export const Link: FunctionalComponent<LinkProps> = (
         urlMatch = url,
         exact,
         strict,
+        external = false,
         forceRefresh = false,
         updateScroll = true,
         activeClass = 'link-active',
@@ -63,7 +66,13 @@ export const Link: FunctionalComponent<LinkProps> = (
 
     return (
         <Element
-            href={disabled || url == null ? undefined : router.getUrl(url)}
+            href={
+                disabled || url == null
+                    ? undefined
+                    : external
+                    ? url
+                    : router.getUrl(url)
+            }
             class={{
                 [activeClass]: !!match,
                 ...(typeof classes === 'string'
@@ -79,6 +88,7 @@ export const Link: FunctionalComponent<LinkProps> = (
                 if (
                     cancel === false ||
                     disabled ||
+                    external ||
                     forceRefresh ||
                     isModifiedEvent(e) ||
                     url == null


### PR DESCRIPTION
- extend "external" vs "forceRefresh" concept to router
  - "forceRefresh": an internal link that breaks from the router.
  - "external": an external link, breaks from the router and has no baseUrl applied
 - use new external prop in `es-button-link`