### PR TITLE
Allow trailing slashes in routes

### DIFF
--- a/documentation/src/screens/package/package.tsx
+++ b/documentation/src/screens/package/package.tsx
@@ -1,4 +1,4 @@
-import { Route, Switch } from '@eventstore-ui/router';
+import { Redirect, Route, Switch } from '@eventstore-ui/router';
 import { Component, h, Prop } from '@stencil/core';
 import { Host, Watch } from '@stencil/core/internal';
 import { sitemap } from 'sitemap';
@@ -189,6 +189,9 @@ export class DocsPackage {
                             <docs-type-docs lib={lib} doc={doc} />
                         </Route>
                     ))}
+                    <Route>
+                        <Redirect url={`/${this.slug}`} />
+                    </Route>
                 </Switch>
             </Host>
         );

--- a/packages/router/src/components/Route.tsx
+++ b/packages/router/src/components/Route.tsx
@@ -11,6 +11,8 @@ export interface RouteProps {
     url?: string | string[];
     /** If the url should match exactly, or allow decendant matching. */
     exact?: boolean;
+    /**  When true the regexp won't allow an optional trailing delimiter to match. */
+    strict?: boolean;
     /** Callback to render the route. */
     routeRender?: (props: RouteRenderProps) => VNode | VNode[];
 }
@@ -24,14 +26,14 @@ export const ROUTE_DELIMITER = '\n'.repeat(3);
  */
 
 export const Route: FunctionalComponent<RouteProps> = (
-    { url, exact, routeRender },
+    { url, exact, strict, routeRender },
     children,
     utils,
 ) => {
     const match = getInternalRouter().match({
-        exact: exact,
+        exact,
         path: url,
-        strict: true,
+        strict,
     });
 
     if (!match) {


### PR DESCRIPTION
- Change default `Route` behaviour to allow trailing slashes
- Add strict prop to `Route` to control the behaviour
- Return redirect to docs, as github-pages trailing slashes was triggering the redirect