### PR TITLE
Bump json5 from 2.1.3 and 2.2.1 to 2.2.3

### DIFF
--- a/.yarn/cache/json5-npm-2.1.3-b71ec6bcca-b2de57a665.zip
+++ b/.yarn/cache/json5-npm-2.1.3-b71ec6bcca-b2de57a665.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67ee6c8f1d6ecfd6a44b67771439d9c288c401353ba3ed614d642de527a067fa
-size 60725

--- a/.yarn/cache/json5-npm-2.2.1-44675c859c-74b8a23b10.zip
+++ b/.yarn/cache/json5-npm-2.2.1-44675c859c-74b8a23b10.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:612e88dce20dd596f5384da62732b65021bcfa8675fb306d75a22d0890f1797c
-size 58466

--- a/.yarn/cache/json5-npm-2.2.3-9962c55073-2a7436a933.zip
+++ b/.yarn/cache/json5-npm-2.2.3-9962c55073-2a7436a933.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca8a814b2f1584a3a7c0301e0836d01336eff31c49fc64dfa9b9dede0f720575
+size 60244

--- a/yarn.lock
+++ b/yarn.lock
@@ -8074,23 +8074,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2":
-  version: 2.1.3
-  resolution: "json5@npm:2.1.3"
-  dependencies:
-    minimist: ^1.2.5
+"json5@npm:^2.1.2, json5@npm:^2.2.0, json5@npm:^2.2.1":
+  version: 2.2.3
+  resolution: "json5@npm:2.2.3"
   bin:
     json5: lib/cli.js
-  checksum: b2de57a66520eca0fbb6c5ef59249b8308efb93fe89a8c75f5a6846e4f5f7d99a5a6f2e4db4d7a1c7047802dd816ed602a052d147a415d0e6b7f834885b62bc3
-  languageName: node
-  linkType: hard
-
-"json5@npm:^2.2.0, json5@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "json5@npm:2.2.1"
-  bin:
-    json5: lib/cli.js
-  checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b
+  checksum: 2a7436a93393830bce797d4626275152e37e877b265e94ca69c99e3d20c2b9dab021279146a39cdb700e71b2dd32a4cebd1514cd57cee102b1af906ce5040349
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11861797/211515388-cfc3b7f9-303f-4487-a3c4-11ff96193d8c.png)
