### PR TITLE
es-input-list improvements

### DIFF
--- a/packages/fields/src/components/es-input-list/es-input-list.css
+++ b/packages/fields/src/components/es-input-list/es-input-list.css
@@ -20,8 +20,14 @@ es-input:not(:first-of-type)::part(label) {
     align-items: center;
 }
 
+.delete_row {
+    width: fit-content;
+    --border-radius: 50%;
+}
+
 .add_item {
     grid-column: input;
     justify-self: end;
     --text-color: var(--color-text);
+    --border-radius: 20px;
 }

--- a/packages/fields/src/components/es-input-list/usage/es-input-list.demo.css
+++ b/packages/fields/src/components/es-input-list/usage/es-input-list.demo.css
@@ -1,0 +1,4 @@
+:host {
+    max-width: 5000px;
+    margin: auto;
+}

--- a/packages/fields/src/components/es-input-list/usage/es-input-list.demo.tsx
+++ b/packages/fields/src/components/es-input-list/usage/es-input-list.demo.tsx
@@ -1,0 +1,37 @@
+import { Component, h, Listen, State } from '@stencil/core';
+import type { FieldChangeEvent } from '../../../types';
+
+/** es-input-list demo. */
+@Component({
+    tag: 'es-input-list-demo',
+    styleUrl: 'es-input-list.demo.css',
+    shadow: true,
+})
+export class Demo {
+    @State() value: string[] = [''];
+
+    @Listen('fieldchange')
+    onFieldChange(e: FieldChangeEvent<string[]>) {
+        this.value = e.detail.value;
+    }
+
+    render() {
+        return (
+            <es-accordian
+                sections={[
+                    {
+                        name: 'input-list',
+                    },
+                ]}
+            >
+                <es-input-list
+                    label={'Input List'}
+                    name={'list'}
+                    placeholder={'placeholder'}
+                    value={this.value}
+                    slot={'input-list'}
+                />
+            </es-accordian>
+        );
+    }
+}


### PR DESCRIPTION
- enter on a field adds a field and focus it.
- Clicking `add field` should focusses field.
- Clicking `add field` when last field is empty just focuses it.
- add demo for `es-list-input`

fixes: #270 