### PR TITLE
Update to stencil v3

### DIFF
--- a/.yarn/cache/@stencil-core-npm-2.17.4-e4f72f550c-cb7496a58f.zip
+++ b/.yarn/cache/@stencil-core-npm-2.17.4-e4f72f550c-cb7496a58f.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:160b70f4462b961da25d7ac9666ba6ca7dafc713f35c4575370839e82faa4d4e
-size 4042138

--- a/.yarn/cache/@stencil-core-npm-3.0.0-e7c09cc3b4-1396d1e686.zip
+++ b/.yarn/cache/@stencil-core-npm-3.0.0-e7c09cc3b4-1396d1e686.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da28937bbf7a5fc828d187fae37552cf96ac473b2e850aa22aea3a6716c81ce8
-size 4269449

--- a/.yarn/cache/@stencil-core-npm-3.0.0-e7c09cc3b4-1396d1e686.zip
+++ b/.yarn/cache/@stencil-core-npm-3.0.0-e7c09cc3b4-1396d1e686.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da28937bbf7a5fc828d187fae37552cf96ac473b2e850aa22aea3a6716c81ce8
+size 4269449

--- a/.yarn/cache/@stencil-core-npm-3.0.1-3a20d7e767-fe4f031063.zip
+++ b/.yarn/cache/@stencil-core-npm-3.0.1-3a20d7e767-fe4f031063.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfd03d2ce7231b76f314b15daad15b503ab90544727ea0a2feb58a06d5ae603b
+size 4271594

--- a/.yarn/cache/@types-node-npm-14.0.27-d33df6dc81-8068203dc8.zip
+++ b/.yarn/cache/@types-node-npm-14.0.27-d33df6dc81-8068203dc8.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01e9124759a8434954a0f396304c993587f6ad2558ae88d1c519aae4a95defea
-size 124082

--- a/.yarn/cache/@types-node-npm-16.11.11-d8efa4328b-1c472bd63f.zip
+++ b/.yarn/cache/@types-node-npm-16.11.11-d8efa4328b-1c472bd63f.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fee2aa297613f642639d85ac9a0a941d005bf0c329a4cc2adf9ca51c9a80e4a
-size 331013

--- a/.yarn/cache/@types-node-npm-18.11.18-d61e8a4a20-03f17f9480.zip
+++ b/.yarn/cache/@types-node-npm-18.11.18-d61e8a4a20-03f17f9480.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb753a1d6e315a30e691069eb2db55b7f00d1db243b41db087c9014a66fbf00
+size 708380

--- a/.yarn/cache/caniuse-lite-npm-1.0.30001373-2250b6de69-cd2f027e2f.zip
+++ b/.yarn/cache/caniuse-lite-npm-1.0.30001373-2250b6de69-cd2f027e2f.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:578b6ebb34b551ffc09f868d34901ee8effe82a2e9e63116988404742cecd3cb
-size 728120

--- a/.yarn/cache/caniuse-lite-npm-1.0.30001449-e0e124442f-f1b395f0a5.zip
+++ b/.yarn/cache/caniuse-lite-npm-1.0.30001449-e0e124442f-f1b395f0a5.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be9198f232fd33d4a8558794f1cc5e0e4763d3f0fa6bca9b55086763a6954733
+size 742330

--- a/.yarn/cache/cosmiconfig-npm-8.0.0-1cab0f7583-ff4cdf89ac.zip
+++ b/.yarn/cache/cosmiconfig-npm-8.0.0-1cab0f7583-ff4cdf89ac.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b784aa98644e07de491c8dbc7455491b267e6cac96bacd9ea4b924aabde659c
+size 39932

--- a/.yarn/cache/cross-fetch-npm-3.1.5-e414995db9-f6b8c6ee3e.zip
+++ b/.yarn/cache/cross-fetch-npm-3.1.5-e414995db9-f6b8c6ee3e.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddeb09f652a969a019b5249369ce248771d3490da8f1fd3f6bff28e342cb7a1a
+size 26317

--- a/.yarn/cache/debug-npm-4.3.1-22e08d605e-2c3352e37d.zip
+++ b/.yarn/cache/debug-npm-4.3.1-22e08d605e-2c3352e37d.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bb3a630e38fbe4879bbb9fcda8a5b99a1d7f9181fb0012baa1e343cce8baf50
-size 15270

--- a/.yarn/cache/debug-npm-4.3.4-4513954577-3dbad3f94e.zip
+++ b/.yarn/cache/debug-npm-4.3.4-4513954577-3dbad3f94e.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e00c6a4f78b6a36df483d7be6a4f6a61870fad2784e8cd13d63d55f6055d8f62
+size 15777

--- a/.yarn/cache/devtools-protocol-npm-0.0.1082910-9a94cf030f-62b95b58f3.zip
+++ b/.yarn/cache/devtools-protocol-npm-0.0.1082910-9a94cf030f-62b95b58f3.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8daf99cd88f11f9a990c9067359e4ff71830356ec1a61edb437cf677328e3ab
+size 377226

--- a/.yarn/cache/devtools-protocol-npm-0.0.901419-b95044bb43-de68331ddf.zip
+++ b/.yarn/cache/devtools-protocol-npm-0.0.901419-b95044bb43-de68331ddf.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cba22c503517c1e9daf59f03eeeb47a0c99b9a69bee48f390ecb645aa962afe1
-size 506025

--- a/.yarn/cache/glob-npm-7.2.0-bb4644d239-78a8ea9423.zip
+++ b/.yarn/cache/glob-npm-7.2.0-bb4644d239-78a8ea9423.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92790993cadaf57c81a4edfb9c01d4f669ef11b171eaab3f401ac06c35be0ee0
-size 19503

--- a/.yarn/cache/https-proxy-agent-npm-5.0.1-42d65f358e-571fccdf38.zip
+++ b/.yarn/cache/https-proxy-agent-npm-5.0.1-42d65f358e-571fccdf38.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32757a713b555c3551dfb53604a7d6fd7a0e118a1a214ed40a7fabdaea2066e7
+size 11991

--- a/.yarn/cache/jsonc-parser-npm-3.0.0-66e692e88a-1df2326f1f.zip
+++ b/.yarn/cache/jsonc-parser-npm-3.0.0-66e692e88a-1df2326f1f.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03ae5a1a42e8bf086b546484d5224eb5059ae4d2a07f56bf1728ed19f0d03505
-size 41337

--- a/.yarn/cache/marked-npm-4.0.12-1fc6e0ed31-7575117f85.zip
+++ b/.yarn/cache/marked-npm-4.0.12-1fc6e0ed31-7575117f85.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d307c412ee36b3d2179601b9afcae51f0e6cc0359a80c0b85ef10e66089c8127
-size 111719

--- a/.yarn/cache/marked-npm-4.2.12-59aaa5afdc-bd551cd610.zip
+++ b/.yarn/cache/marked-npm-4.2.12-59aaa5afdc-bd551cd610.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5847d98fc6a6f112bbd9a6d5bb5d754c09036f9c16f21a8b6b01ed50cee8e3dc
+size 115430

--- a/.yarn/cache/minimatch-npm-5.1.6-1e71429f4c-7564208ef8.zip
+++ b/.yarn/cache/minimatch-npm-5.1.6-1e71429f4c-7564208ef8.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5649b9e60a55694d092c13e7b62e63febf4cffd48be99956063e102b41ef4dd
+size 14344

--- a/.yarn/cache/mkdirp-classic-npm-0.5.3-3b5c991910-3f4e088208.zip
+++ b/.yarn/cache/mkdirp-classic-npm-0.5.3-3b5c991910-3f4e088208.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6a75adc9f8d6dee8d00505d6b5828bdba05563f377149450fe5cca845efb2e8
+size 2685

--- a/.yarn/cache/mkdirp-npm-0.5.5-6bc76534fc-3bce20ea52.zip
+++ b/.yarn/cache/mkdirp-npm-0.5.5-6bc76534fc-3bce20ea52.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b236df1b49d09ab3a43f1d4defc87e04476fd96b7988d247fce1032e1c874f0
-size 4361

--- a/.yarn/cache/progress-npm-2.0.1-256de96838-46d1f5a5df.zip
+++ b/.yarn/cache/progress-npm-2.0.1-256de96838-46d1f5a5df.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:959759cd8f76d7b2bba42a041d36ff2977b0fa2e4f493fc1a0a4a2703333cc5b
-size 7623

--- a/.yarn/cache/puppeteer-core-npm-19.6.2-dc3c317782-92325f78de.zip
+++ b/.yarn/cache/puppeteer-core-npm-19.6.2-dc3c317782-92325f78de.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3356a95e7a1815967ebfc21d4958b320757b74f7e0e74ec1ee9ed1366883e780
+size 1408015

--- a/.yarn/cache/puppeteer-npm-10.4.0-2cff9d6bb6-3b7b628f07.zip
+++ b/.yarn/cache/puppeteer-npm-10.4.0-2cff9d6bb6-3b7b628f07.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1996f62d953b296882d22ab736004e63fa1fc837f297a0b4e4baa7a520c447f5
-size 839976

--- a/.yarn/cache/puppeteer-npm-19.6.2-c58a8f28f2-7ed12a8be7.zip
+++ b/.yarn/cache/puppeteer-npm-19.6.2-c58a8f28f2-7ed12a8be7.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a4b3aa4a9b72c749c0017c7494999929916e39933c5d8fa17b291ffb6805a18
+size 84918

--- a/.yarn/cache/rollup-npm-2.23.0-7d888f752f-a65b796ec9.zip
+++ b/.yarn/cache/rollup-npm-2.23.0-7d888f752f-a65b796ec9.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ba130538c4380698501fe4f16abcdcb0193ed356c62a81bffb52a39850cbfec
-size 678268

--- a/.yarn/cache/rollup-npm-2.33.1-8153b21b24-b9c869bd24.zip
+++ b/.yarn/cache/rollup-npm-2.33.1-8153b21b24-b9c869bd24.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:283eaa783897791d4b80be7d64cd31f322dfde4ebcb2a53fd9d92ea82c1cbada
-size 700060

--- a/.yarn/cache/rollup-npm-2.52.7-229534540c-92629c518c.zip
+++ b/.yarn/cache/rollup-npm-2.52.7-229534540c-92629c518c.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40ef83df66bd86c39a82d780945d7ab74f1f1c69332cc163b0f78f0a69ded66e
-size 1086988

--- a/.yarn/cache/rollup-npm-2.77.2-71ff03fa85-5a84fb98a6.zip
+++ b/.yarn/cache/rollup-npm-2.77.2-71ff03fa85-5a84fb98a6.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:027f820ccfdf68a01be1b86834020fe1ecc1ec39dfd8749c4946e969311d4bf6
-size 1211023

--- a/.yarn/cache/rollup-npm-2.79.1-94e707a9a3-6a2bf167b3.zip
+++ b/.yarn/cache/rollup-npm-2.79.1-94e707a9a3-6a2bf167b3.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acbea6bdf22e74c59f6638272939bef4be0e1eb91ab9dfea510d75b0e664f948
+size 1215150

--- a/.yarn/cache/rollup-plugin-inject-npm-3.0.2-db1d368b18-a014972c80.zip
+++ b/.yarn/cache/rollup-plugin-inject-npm-3.0.2-db1d368b18-a014972c80.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c803ca020645368f0d52cc30bd4e436fa2d777fa6ed8cc7cfe599a8fad3ddf3
-size 9110

--- a/.yarn/cache/rollup-plugin-node-polyfills-npm-0.2.1-d0e4f85f30-e84645212c.zip
+++ b/.yarn/cache/rollup-plugin-node-polyfills-npm-0.2.1-d0e4f85f30-e84645212c.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f92a7996b04cc6799e0bd1c9e63e59f4e1c9c76e94a7c09ad2e07d901216128
-size 394658

--- a/.yarn/cache/rollup-plugin-require-context-npm-0.0.2-25be71626f-321acdb522.zip
+++ b/.yarn/cache/rollup-plugin-require-context-npm-0.0.2-25be71626f-321acdb522.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6429a77ff162a9fd3ca10240fe1ac0beb68a236d1d9e549764694ec942d55e1d
-size 3660

--- a/.yarn/cache/shiki-npm-0.10.1-2c9519a6d0-fb746f3cb3.zip
+++ b/.yarn/cache/shiki-npm-0.10.1-2c9519a6d0-fb746f3cb3.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb1922ad5f082918a7af06c0e80d5a9d100a5b0170d31b1d3f168aab13fc90ef
-size 1211898

--- a/.yarn/cache/shiki-npm-0.12.1-f591afd43a-a5d78a79d2.zip
+++ b/.yarn/cache/shiki-npm-0.12.1-f591afd43a-a5d78a79d2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b25c94a16c5a2ed796cc082623b498c2a11b1d90fc5e9b3291765e2209f3ace9
+size 1257693

--- a/.yarn/cache/tar-fs-npm-2.0.0-1b39aabf20-f15079cd7e.zip
+++ b/.yarn/cache/tar-fs-npm-2.0.0-1b39aabf20-f15079cd7e.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc376c02bb0b4a820a6944ab7395068ec59948e14e86e9cbb29897a618f4c4f6
-size 11519

--- a/.yarn/cache/tar-fs-npm-2.1.1-e374d3b7a2-f5b9a70059.zip
+++ b/.yarn/cache/tar-fs-npm-2.1.1-e374d3b7a2-f5b9a70059.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1379396dd116396439ce0427100e020e0c05d717c1e472d1159b42793f114e6b
+size 11662

--- a/.yarn/cache/tar-stream-npm-2.1.3-fb402ac0e2-7102598974.zip
+++ b/.yarn/cache/tar-stream-npm-2.1.3-fb402ac0e2-7102598974.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f181adb81e79148430f98bf4d0f74378501ed9e9334f26a641e1aadd0e53cab4
-size 10617

--- a/.yarn/cache/typedoc-npm-0.22.13-61c93d1213-e453114fbb.zip
+++ b/.yarn/cache/typedoc-npm-0.22.13-61c93d1213-e453114fbb.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78f6b39c15b669ef87b0a3a176374ad23cb4ef19efdf4fa7dd1f55633d434b46
-size 386010

--- a/.yarn/cache/typedoc-npm-0.23.24-10e99bf8b6-b04f9afcba.zip
+++ b/.yarn/cache/typedoc-npm-0.23.24-10e99bf8b6-b04f9afcba.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f155cddc0ad2d94e1bdda6c929809fdd3f6ef598858d06364da659f7c546806c
+size 347754

--- a/.yarn/cache/typescript-npm-4.5.5-b3e3678b69-506f4c919d.zip
+++ b/.yarn/cache/typescript-npm-4.5.5-b3e3678b69-506f4c919d.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6088c30ee7ce3a9be8a2609503dfa8d7f9c99e156f4ea90f550a31b92cf0601
-size 11270676

--- a/.yarn/cache/typescript-npm-4.9.4-51bdca3293-e782fb9e00.zip
+++ b/.yarn/cache/typescript-npm-4.9.4-51bdca3293-e782fb9e00.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63348d4525a5c8d64224057cd6ff7a100ac0f7c49bc280576ff814415a44ce55
+size 11682518

--- a/.yarn/cache/typescript-patch-6c4da7c8b8-9cdde4aae2.zip
+++ b/.yarn/cache/typescript-patch-6c4da7c8b8-9cdde4aae2.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e8d4258a5616f6f83408ccef27ca3b7ac9f5104bc5ad527e8fa350b0cd4c439
-size 11270676

--- a/.yarn/cache/typescript-patch-d0c2075356-37f6e2c3c5.zip
+++ b/.yarn/cache/typescript-patch-d0c2075356-37f6e2c3c5.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0e85e2b3efcf9d3d1bab6c35e1c2c9ebd8fd1b578ad89fc65219423d691ecc1
+size 11682518

--- a/.yarn/cache/unbzip2-stream-npm-1.3.3-7c09e221ed-5ae179e609.zip
+++ b/.yarn/cache/unbzip2-stream-npm-1.3.3-7c09e221ed-5ae179e609.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9e3cd96d0c890e0acd18c50364e407c4e13b40b0fb25383429c30d02abbbcc6
-size 37975

--- a/.yarn/cache/unbzip2-stream-npm-1.4.3-c5582d6a9f-0e67c4a91f.zip
+++ b/.yarn/cache/unbzip2-stream-npm-1.4.3-c5582d6a9f-0e67c4a91f.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf642214af1cadc48fbae98df0cacad206b95e2b2e8ca338948a08677a641617
+size 37987

--- a/.yarn/cache/vscode-oniguruma-npm-1.6.2-a8a5319111-6b754acdaf.zip
+++ b/.yarn/cache/vscode-oniguruma-npm-1.6.2-a8a5319111-6b754acdaf.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bd2310fcbcc2a26c94e565fe2994b5a71f7a5bcc074c5941c85c27202c04237
-size 159594

--- a/.yarn/cache/vscode-oniguruma-npm-1.7.0-07cc55fbcc-53519d91d9.zip
+++ b/.yarn/cache/vscode-oniguruma-npm-1.7.0-07cc55fbcc-53519d91d9.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25e7ff1ca972362ad3427c5cae170fd280ccbb75945b617e749dd913ada91a03
+size 162024

--- a/.yarn/cache/vscode-textmate-npm-5.2.0-82267678b1-5449b42d45.zip
+++ b/.yarn/cache/vscode-textmate-npm-5.2.0-82267678b1-5449b42d45.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60cd7a809ccee0188b9d3be1727002b8839c2163a3c7d841466d1f64eff62bf5
-size 80951

--- a/.yarn/cache/vscode-textmate-npm-8.0.0-2deb0cc7cf-127780dfea.zip
+++ b/.yarn/cache/vscode-textmate-npm-8.0.0-2deb0cc7cf-127780dfea.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d24fdac3f7c380bbe8a18254d8df10ba71f4842897c6f82275728b0fcaf41b54
+size 94328

--- a/.yarn/cache/ws-npm-7.4.6-9c9a725604-3a990b32ed.zip
+++ b/.yarn/cache/ws-npm-7.4.6-9c9a725604-3a990b32ed.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba5d518ae5af6cc8476e034b9163a69e0e5ebc3cbc8f27bee166437ab739332f
-size 34117

--- a/.yarn/cache/ws-npm-8.11.0-ab72116a01-316b33aba3.zip
+++ b/.yarn/cache/ws-npm-8.11.0-ab72116a01-316b33aba3.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1506616713a313321ec5dcc737ed4d7ca1e35666d8cf27d1f9a0e7847eacccd
+size 39437

--- a/demos/forms-demo/package.json
+++ b/demos/forms-demo/package.json
@@ -23,6 +23,6 @@
         "@eventstore-ui/assets": "workspace:*",
         "@eventstore-ui/configs": "workspace:*",
         "@eventstore-ui/icon-manager": "workspace:*",
-        "@stencil/core": "3.0.0"
+        "@stencil/core": "3.0.1"
     }
 }

--- a/demos/forms-demo/package.json
+++ b/demos/forms-demo/package.json
@@ -23,6 +23,6 @@
         "@eventstore-ui/assets": "workspace:*",
         "@eventstore-ui/configs": "workspace:*",
         "@eventstore-ui/icon-manager": "workspace:*",
-        "@stencil/core": "2.17.4"
+        "@stencil/core": "3.0.0"
     }
 }

--- a/demos/router-demo/package.json
+++ b/demos/router-demo/package.json
@@ -14,6 +14,6 @@
         "@eventstore-ui/router": "workspace:*"
     },
     "devDependencies": {
-        "@stencil/core": "3.0.0"
+        "@stencil/core": "3.0.1"
     }
 }

--- a/demos/router-demo/package.json
+++ b/demos/router-demo/package.json
@@ -14,6 +14,6 @@
         "@eventstore-ui/router": "workspace:*"
     },
     "devDependencies": {
-        "@stencil/core": "2.17.4"
+        "@stencil/core": "3.0.0"
     }
 }

--- a/demos/stores-demo/package.json
+++ b/demos/stores-demo/package.json
@@ -15,6 +15,6 @@
         "@eventstore-ui/utils": "workspace:*"
     },
     "devDependencies": {
-        "@stencil/core": "3.0.0"
+        "@stencil/core": "3.0.1"
     }
 }

--- a/demos/stores-demo/package.json
+++ b/demos/stores-demo/package.json
@@ -15,6 +15,6 @@
         "@eventstore-ui/utils": "workspace:*"
     },
     "devDependencies": {
-        "@stencil/core": "2.17.4"
+        "@stencil/core": "3.0.0"
     }
 }

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -52,7 +52,7 @@
         "@eventstore-ui/assets": "workspace:*",
         "@eventstore-ui/configs": "workspace:*",
         "@eventstore-ui/icon-manager": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "@stencil/postcss": "^2.1.0",
         "@types/jest": "^27.0.3",
         "@types/markdown-it": "12.0.3",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -34,6 +34,7 @@
         "@eventstore-ui/components": "workspace:*",
         "@eventstore-ui/editor": "workspace:*",
         "@eventstore-ui/fields": "workspace:*",
+        "@eventstore-ui/forms": "workspace:*",
         "@eventstore-ui/illustrations": "workspace:*",
         "@eventstore-ui/layout": "workspace:*",
         "@eventstore-ui/router": "workspace:*",
@@ -45,7 +46,7 @@
         "markdown-it": "12.3.2",
         "markdown-it-anchor": "8.6.4",
         "prettier": "2.2.1",
-        "rollup": "2.33.1"
+        "rollup": "^2.52.7"
     },
     "devDependencies": {
         "@eventstore-ui/assets": "workspace:*",
@@ -60,8 +61,6 @@
         "npm-run-all": "^4.1.5",
         "postcss-preset-env": "6.7.0",
         "puppeteer": "^19.5.0",
-        "rollup-plugin-node-polyfills": "0.2.1",
-        "rollup-plugin-require-context": "0.0.2",
         "rollup-plugin-string": "3.0.0",
         "serve": "14.0.1",
         "typedoc": "0.23.24",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -51,7 +51,7 @@
         "@eventstore-ui/assets": "workspace:*",
         "@eventstore-ui/configs": "workspace:*",
         "@eventstore-ui/icon-manager": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "@stencil/postcss": "^2.1.0",
         "@types/jest": "^27.0.3",
         "@types/markdown-it": "12.0.3",
@@ -59,13 +59,13 @@
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "postcss-preset-env": "6.7.0",
-        "puppeteer": "10.4.0",
+        "puppeteer": "^19.5.0",
         "rollup-plugin-node-polyfills": "0.2.1",
         "rollup-plugin-require-context": "0.0.2",
         "rollup-plugin-string": "3.0.0",
         "serve": "14.0.1",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5",
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4",
         "workbox-build": "6.5.4"
     }
 }

--- a/documentation/preview/src/components.d.ts
+++ b/documentation/preview/src/components.d.ts
@@ -6,6 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { LocationSegments, Router } from "@eventstore-ui/router";
+export { LocationSegments, Router } from "@eventstore-ui/router";
 export namespace Components {
     interface PreviewUsageLocation {
         "location"?: LocationSegments;

--- a/documentation/src/components.d.ts
+++ b/documentation/src/components.d.ts
@@ -9,6 +9,10 @@ import { JsonDocs, JsonDocsEvent, JsonDocsMethod, JsonDocsPart, JsonDocsProp, Js
 import { Lib } from "sitemap";
 import { SomeReflection } from "utils/typedoc/types";
 import { SomeType } from "typedoc";
+export { JsonDocs, JsonDocsEvent, JsonDocsMethod, JsonDocsPart, JsonDocsProp, JsonDocsSlot, JsonDocsStyle } from "@stencil/core/internal";
+export { Lib } from "sitemap";
+export { SomeReflection } from "utils/typedoc/types";
+export { SomeType } from "typedoc";
 export namespace Components {
     interface DocsBackground {
     }

--- a/documentation/src/components/docs-type-documentation/components/ClassTable.tsx
+++ b/documentation/src/components/docs-type-documentation/components/ClassTable.tsx
@@ -6,8 +6,8 @@ import type { SomeReflection } from 'utils/typedoc/types';
 export const ClassTable: FunctionalComponent<{
     declaration: DeclarationReflection;
 }> = ({ declaration }) => {
-    const props = !!declaration.comment?.tags?.find(
-        (tag) => tag.tagName === 'props' || tag.tagName === 'options',
+    const props = !!declaration.comment?.blockTags?.find(
+        (tag) => tag.tag === '@props' || tag.tag === '@options',
     );
 
     return (
@@ -36,7 +36,7 @@ const expandAndFilterSignatures = (declarations: SomeReflection[]) =>
         )
         .filter(
             (d) =>
-                !d.comment?.tags?.find(({ tagName }) => tagName === 'internal'),
+                !d.comment?.blockTags?.find(({ tag }) => tag === '@internal'),
         );
 
 const cells: TableCells<DeclarationReflection> = {
@@ -46,8 +46,8 @@ const cells: TableCells<DeclarationReflection> = {
             <docs-type
                 string={name}
                 depreciated={
-                    !!comment?.tags?.find(
-                        ({ tagName }) => tagName === 'depreciated',
+                    !!comment?.blockTags?.find(
+                        ({ tag }) => tag === '@depreciated',
                     )
                 }
             />
@@ -57,8 +57,8 @@ const cells: TableCells<DeclarationReflection> = {
     docs: {
         title: 'Description',
         cell: (h, { data: { comment } }) => {
-            const deprecation = comment?.tags?.find(
-                ({ tagName }) => tagName === 'depreciated',
+            const deprecation = comment?.blockTags?.find(
+                ({ tag }) => tag === '@depreciated',
             );
 
             return (
@@ -67,10 +67,19 @@ const cells: TableCells<DeclarationReflection> = {
                         class={{
                             depreciated: !!deprecation,
                         }}
-                        md={comment?.text ?? comment?.shortText ?? ''}
+                        md={
+                            comment?.summary.map(({ text }) => text).join('') ??
+                            ''
+                        }
                     />
                     {deprecation && (
-                        <docs-markdown md={deprecation.text ?? ''} />
+                        <docs-markdown
+                            md={
+                                deprecation.content
+                                    .map(({ text }) => text)
+                                    .join('') ?? ''
+                            }
+                        />
                     )}
                 </>
             );

--- a/documentation/src/components/docs-type-documentation/components/InterfaceTable.tsx
+++ b/documentation/src/components/docs-type-documentation/components/InterfaceTable.tsx
@@ -6,8 +6,8 @@ import type { SomeReflection } from 'utils/typedoc/types';
 export const InterfaceTable: FunctionalComponent<{
     declaration: DeclarationReflection;
 }> = ({ declaration }) => {
-    const props = !!declaration.comment?.tags?.find(
-        (tag) => tag.tagName === 'props' || tag.tagName === 'options',
+    const props = !!declaration.comment?.blockTags?.find(
+        (tag) => tag.tag === '@props' || tag.tag === '@options',
     );
 
     return (
@@ -36,7 +36,7 @@ const expandAndFilterSignatures = (declarations: DeclarationReflection[]) =>
         )
         .filter(
             (d) =>
-                !d.comment?.tags?.find(({ tagName }) => tagName === 'internal'),
+                !d.comment?.blockTags?.find(({ tag }) => tag === '@internal'),
         );
 
 const cells: TableCells<DeclarationReflection> = {
@@ -46,8 +46,8 @@ const cells: TableCells<DeclarationReflection> = {
             <docs-type
                 string={name}
                 depreciated={
-                    !!comment?.tags?.find(
-                        ({ tagName }) => tagName === 'depreciated',
+                    !!comment?.blockTags?.find(
+                        ({ tag }) => tag === '@depreciated',
                     )
                 }
             />
@@ -57,8 +57,8 @@ const cells: TableCells<DeclarationReflection> = {
     docs: {
         title: 'Description',
         cell: (h, { data: { comment } }) => {
-            const deprecation = comment?.tags?.find(
-                ({ tagName }) => tagName === 'depreciated',
+            const deprecation = comment?.blockTags?.find(
+                ({ tag }) => tag === '@depreciated',
             );
 
             return (
@@ -67,10 +67,19 @@ const cells: TableCells<DeclarationReflection> = {
                         class={{
                             depreciated: !!deprecation,
                         }}
-                        md={comment?.text ?? comment?.shortText ?? ''}
+                        md={
+                            comment?.summary.map(({ text }) => text).join('') ??
+                            ''
+                        }
                     />
                     {deprecation && (
-                        <docs-markdown md={deprecation.text ?? ''} />
+                        <docs-markdown
+                            md={
+                                deprecation.content
+                                    .map(({ text }) => text)
+                                    .join('') ?? ''
+                            }
+                        />
                     )}
                 </>
             );

--- a/documentation/src/declarations.d.ts
+++ b/documentation/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+    const value: string;
+    export = value;
+}

--- a/documentation/src/screens/component-docs/component-docs.tsx
+++ b/documentation/src/screens/component-docs/component-docs.tsx
@@ -63,9 +63,9 @@ export class ComponentDocs {
                         <docs-markdown
                             class={'intro'}
                             md={
-                                doc.comment?.text ??
-                                doc.comment?.shortText ??
-                                ''
+                                doc.comment?.summary
+                                    .map(({ text }) => text)
+                                    .join('') ?? ''
                             }
                         />
                         <docs-type-documentation declaration={doc} />

--- a/documentation/src/screens/functional-component-docs/functional-component-docs.tsx
+++ b/documentation/src/screens/functional-component-docs/functional-component-docs.tsx
@@ -5,11 +5,7 @@ import { Page } from '@eventstore-ui/layout';
 import type { Lib } from 'sitemap';
 import { findAllReferences } from 'utils/typedoc/findAllReferences';
 import { extractUsage } from 'utils/extractUsage';
-import {
-    extractAbstract,
-    extractBodyText,
-    extractFullText,
-} from 'utils/extractText';
+import { extractText } from 'utils/extractText';
 import { hasTag } from 'utils/typedoc/hasTag';
 import type { SomeReflection } from 'utils/typedoc/types';
 
@@ -53,8 +49,7 @@ export class FunctionalComponentDocs {
                     },
                 ]}
             >
-                <docs-markdown class={'intro'} md={extractAbstract(this.doc)} />
-                <docs-markdown class={'body'} md={extractBodyText(this.doc)} />
+                <docs-markdown class={'body'} md={extractText(this.doc)} />
 
                 {Object.entries(extractUsage(this.doc)).map(
                     ([uname, usage]) => (
@@ -69,10 +64,7 @@ export class FunctionalComponentDocs {
                 {this.references.map((doc) => (
                     <div key={doc.name} id={doc.name}>
                         <h2>{hasTag(doc, 'props') ? 'Props' : doc.name}</h2>
-                        <docs-markdown
-                            class={'intro'}
-                            md={extractFullText(doc)}
-                        />
+                        <docs-markdown class={'intro'} md={extractText(doc)} />
                         <docs-type-documentation declaration={doc} />
                     </div>
                 ))}

--- a/documentation/src/screens/type-docs/type-docs.tsx
+++ b/documentation/src/screens/type-docs/type-docs.tsx
@@ -4,7 +4,7 @@ import { Page } from '@eventstore-ui/layout';
 
 import type { Lib } from 'sitemap';
 import { findAllReferences } from 'utils/typedoc/findAllReferences';
-import { extractAbstract } from 'utils/extractText';
+import { extractText } from 'utils/extractText';
 import { extractUsage } from 'utils/extractUsage';
 import type { SomeReflection } from 'utils/typedoc/types';
 
@@ -44,7 +44,7 @@ export class TypeDocs {
                     },
                 ]}
             >
-                <docs-markdown class={'intro'} md={extractAbstract(this.doc)} />
+                <docs-markdown class={'intro'} md={extractText(this.doc)} />
 
                 {Object.entries(extractUsage(this.doc)).map(
                     ([uname, usage]) => (
@@ -64,9 +64,9 @@ export class TypeDocs {
                         <docs-markdown
                             class={'intro'}
                             md={
-                                doc.comment?.text ??
-                                doc.comment?.shortText ??
-                                ''
+                                doc.comment?.summary
+                                    .map(({ text }) => text)
+                                    .join('') ?? ''
                             }
                         />
                         <docs-type-documentation declaration={doc} />

--- a/documentation/src/screens/util-docs/util-docs.tsx
+++ b/documentation/src/screens/util-docs/util-docs.tsx
@@ -7,7 +7,7 @@ import { findAllReferences } from 'utils/typedoc/findAllReferences';
 import { isVariable } from 'utils/typedoc/reflectionKind';
 import { isReferenceType } from 'utils/typedoc/someType';
 import { extractUsage } from 'utils/extractUsage';
-import { extractAbstract, extractBodyText } from 'utils/extractText';
+import { extractText } from 'utils/extractText';
 import type { SomeReflection } from 'utils/typedoc/types';
 
 @Component({
@@ -52,7 +52,7 @@ export class UtilDocs {
                     },
                 ]}
             >
-                <docs-markdown class={'intro'} md={extractAbstract(this.doc)} />
+                <docs-markdown class={'intro'} md={extractText(this.doc)} />
 
                 {Object.entries(extractUsage(this.doc)).map(
                     ([uname, usage]) => (
@@ -68,17 +68,15 @@ export class UtilDocs {
                     declaration={this.instanceOf ?? this.doc}
                 />
 
-                <docs-markdown class={'body'} md={extractBodyText(this.doc)} />
-
                 {this.references.map((doc) => (
                     <div key={doc.name} id={doc.name}>
                         <h2>{doc.name}</h2>
                         <docs-markdown
                             class={'intro'}
                             md={
-                                doc.comment?.text ??
-                                doc.comment?.shortText ??
-                                ''
+                                doc.comment?.summary
+                                    .map(({ text }) => text)
+                                    .join('') ?? ''
                             }
                         />
                         <docs-type-documentation declaration={doc} />

--- a/documentation/src/utils/expandSitemap/index.ts
+++ b/documentation/src/utils/expandSitemap/index.ts
@@ -2,12 +2,11 @@ import type { JsonDocs } from '@stencil/core/internal';
 import type { ProjectReflection } from 'typedoc';
 import { createTypedocLookup, TypedocLookup } from './createTypedocLookup';
 import { fixTagNames } from './fixTagName';
-
 import {
-    optionallyRequireStencilDocs,
-    optionallyRequireTypeDocs,
-    requirePackageJson,
-    requireReadme,
+    getPackageJson,
+    getReadme,
+    optionallyGetStencilDocs,
+    optionallyGetTypedocs,
 } from './requires';
 
 export interface SectionDefinition {
@@ -103,9 +102,9 @@ export const expandSitemap = (siteDefinition: SectionDefinition[]): Sitemap => {
 };
 
 const expandLib = ({ title, filePath }: LibDefinition): Lib => {
-    const project = fixTagNames(optionallyRequireTypeDocs(slugize(title)));
-    const packageJson = requirePackageJson(`${filePath}/package.json`);
     const slug = slugize(title);
+    const project = fixTagNames(optionallyGetTypedocs(slug));
+    const packageJson = getPackageJson(slug);
 
     return {
         title,
@@ -116,8 +115,8 @@ const expandLib = ({ title, filePath }: LibDefinition): Lib => {
         typeDocs: project
             ? { project, lookup: createTypedocLookup(project) }
             : undefined,
-        stencilDocs: optionallyRequireStencilDocs(slug),
-        readme: requireReadme(`${filePath}/readme.md`),
+        stencilDocs: optionallyGetStencilDocs(slug),
+        readme: getReadme(slug),
     };
 };
 

--- a/documentation/src/utils/expandSitemap/requires.ts
+++ b/documentation/src/utils/expandSitemap/requires.ts
@@ -2,57 +2,120 @@ import type { JsonDocs } from '@stencil/core/internal';
 import type { ProjectReflection } from 'typedoc';
 import type { PackageJson } from '.';
 
-interface RequireContext<T> {
-    (path: string): T;
-    keys: () => string[];
-}
+import componentsPackageJson from '@eventstore-ui/components/package.json';
+import componentsReadme from '@eventstore-ui/components/readme.md';
+import componentsStencilDocs from '../../../generated/components.stencil.json';
+import componentsTypeDocs from '../../../generated/components.typedoc.json';
 
-declare global {
-    interface NodeRequire {
-        context<T>(
-            base: string,
-            useSubdirectories: boolean,
-            regexp: RegExp,
-        ): RequireContext<T>;
-    }
-}
+import configsPackageJson from '@eventstore-ui/configs/package.json';
+import configsReadme from '@eventstore-ui/configs/readme.md';
 
-export const requireReadme = require.context<string>(
-    '../../../../',
-    true,
-    /^((?!node_modules).)*\/readme\.md$/,
-);
+import editorPackageJson from '@eventstore-ui/editor/package.json';
+import editorReadme from '@eventstore-ui/editor/readme.md';
+import editorStencilDocs from '../../../generated/editor.stencil.json';
+import editorTypeDocs from '../../../generated/editor.typedoc.json';
 
-export const requirePackageJson = require.context<PackageJson>(
-    '../../../../',
-    true,
-    /^((?!node_modules|dist).)*\/package\.json$/,
-);
+import fieldsPackageJson from '@eventstore-ui/fields/package.json';
+import fieldsReadme from '@eventstore-ui/fields/readme.md';
+import fieldsStencilDocs from '../../../generated/fields.stencil.json';
+import fieldsTypeDocs from '../../../generated/fields.typedoc.json';
 
-const requireStencilDocs = require.context<JsonDocs>(
-    '../../../generated',
-    true,
-    /.*\.stencil\.json$/,
-);
+import formsPackageJson from '@eventstore-ui/forms/package.json';
+import formsReadme from '@eventstore-ui/forms/readme.md';
+import formsTypeDocs from '../../../generated/forms.typedoc.json';
 
-export const optionallyRequireStencilDocs = (slug: string) => {
-    try {
-        return requireStencilDocs(`./${slug}.stencil.json`);
-    } catch (error) {
-        return undefined;
-    }
+import iconManagerPackageJson from '@eventstore-ui/icon-manager/package.json';
+import iconManagerReadme from '@eventstore-ui/icon-manager/readme.md';
+
+import illustrationsPackageJson from '@eventstore-ui/illustrations/package.json';
+import illustrationsReadme from '@eventstore-ui/illustrations/readme.md';
+import illustrationsStencilDocs from '../../../generated/illustrations.stencil.json';
+import illustrationsTypeDocs from '../../../generated/illustrations.typedoc.json';
+
+import layoutPackageJson from '@eventstore-ui/layout/package.json';
+import layoutReadme from '@eventstore-ui/layout/readme.md';
+import layoutStencilDocs from '../../../generated/layout.stencil.json';
+import layoutTypeDocs from '../../../generated/layout.typedoc.json';
+
+import routerPackageJson from '@eventstore-ui/router/package.json';
+import routerReadme from '@eventstore-ui/router/readme.md';
+import routerTypeDocs from '../../../generated/router.typedoc.json';
+
+import stencilMarkdownPluginPackageJson from '@eventstore-ui/stencil-markdown-plugin/package.json';
+import stencilMarkdownPluginReadme from '@eventstore-ui/stencil-markdown-plugin/readme.md';
+
+import storesPackageJson from '@eventstore-ui/stores/package.json';
+import storesReadme from '@eventstore-ui/stores/readme.md';
+import storesTypeDocs from '../../../generated/stores.typedoc.json';
+
+import themePackageJson from '@eventstore-ui/theme/package.json';
+import themeReadme from '@eventstore-ui/theme/readme.md';
+import themeTypeDocs from '../../../generated/theme.typedoc.json';
+
+import utilsPackageJson from '@eventstore-ui/utils/package.json';
+import utilsReadme from '@eventstore-ui/utils/readme.md';
+import utilsTypeDocs from '../../../generated/utils.typedoc.json';
+
+const packageJsons: Record<string, PackageJson> = {
+    components: componentsPackageJson,
+    configs: configsPackageJson,
+    editor: editorPackageJson,
+    fields: fieldsPackageJson,
+    forms: formsPackageJson,
+    illustrations: illustrationsPackageJson,
+    'icon-manager': iconManagerPackageJson,
+    layout: layoutPackageJson,
+    router: routerPackageJson,
+    'stencil-markdown-plugin': stencilMarkdownPluginPackageJson,
+    stores: storesPackageJson,
+    theme: themePackageJson,
+    utils: utilsPackageJson,
+} as any;
+
+const readmes: Record<string, string> = {
+    components: componentsReadme,
+    configs: configsReadme,
+    editor: editorReadme,
+    fields: fieldsReadme,
+    forms: formsReadme,
+    illustrations: illustrationsReadme,
+    'icon-manager': iconManagerReadme,
+    layout: layoutReadme,
+    router: routerReadme,
+    'stencil-markdown-plugin': stencilMarkdownPluginReadme,
+    stores: storesReadme,
+    theme: themeReadme,
+    utils: utilsReadme,
+} as any;
+
+const stencilDocs: Record<string, JsonDocs> = {
+    components: componentsStencilDocs,
+    editor: editorStencilDocs,
+    fields: fieldsStencilDocs,
+    illustrations: illustrationsStencilDocs,
+    layout: layoutStencilDocs,
+} as any;
+
+const typeDocs: Record<string, ProjectReflection> = {
+    components: componentsTypeDocs,
+    editor: editorTypeDocs,
+    fields: fieldsTypeDocs,
+    forms: formsTypeDocs,
+    illustrations: illustrationsTypeDocs,
+    layout: layoutTypeDocs,
+    router: routerTypeDocs,
+    stores: storesTypeDocs,
+    theme: themeTypeDocs,
+    utils: utilsTypeDocs,
+} as any;
+
+export const getPackageJson = (slug: string) => {
+    if (packageJsons[slug]) return packageJsons[slug];
+    throw `No package.json imported for ${slug}`;
 };
-
-const requireTypeDocs = require.context<ProjectReflection>(
-    '../../../generated',
-    true,
-    /.*\.typedoc\.json$/,
-);
-
-export const optionallyRequireTypeDocs = (slug: string) => {
-    try {
-        return requireTypeDocs(`./${slug}.typedoc.json`);
-    } catch (error) {
-        return undefined;
-    }
+export const getReadme = (slug: string) => {
+    if (readmes[slug]) return readmes[slug];
+    throw `No readme imported for ${slug}`;
 };
+export const optionallyGetStencilDocs = (slug: string) => stencilDocs[slug];
+export const optionallyGetTypedocs = (slug: string) => typeDocs[slug];

--- a/documentation/src/utils/extractText.ts
+++ b/documentation/src/utils/extractText.ts
@@ -1,47 +1,17 @@
 import type { SomeReflection } from './typedoc/types';
 
-export const extractFullText = (refl: SomeReflection): string => {
+export const extractText = (refl: SomeReflection): string => {
     const text = [];
     const comment = refl.comment;
 
     if (comment) {
-        if (comment.shortText) text.push(comment.shortText);
-        if (comment.text) text.push(comment.text);
+        text.push(comment.summary.map(({ text }) => text).join(''));
     } else if ('signatures' in refl && refl.signatures?.length === 1) {
         const [{ comment }] = refl.signatures;
-        if (comment?.shortText) text.push(comment.shortText);
-        if (comment?.text) text.push(comment.text);
+        if (comment) {
+            text.push(comment.summary.map(({ text }) => text).join(''));
+        }
     }
 
     return text.join('\n');
-};
-
-export const extractAbstract = (refl: SomeReflection): string => {
-    const comment = refl.comment;
-
-    if (comment?.shortText) {
-        return comment.shortText;
-    }
-
-    if ('signatures' in refl && refl.signatures?.length === 1) {
-        const [{ comment }] = refl.signatures;
-        if (comment?.shortText) return comment.shortText;
-    }
-
-    return '';
-};
-
-export const extractBodyText = (refl: SomeReflection): string => {
-    const comment = refl.comment;
-
-    if (comment?.text) {
-        return comment.text;
-    }
-
-    if ('signatures' in refl && refl.signatures?.length === 1) {
-        const [{ comment }] = refl.signatures;
-        if (comment?.text) return comment.text;
-    }
-
-    return '';
 };

--- a/documentation/src/utils/extractUsage.ts
+++ b/documentation/src/utils/extractUsage.ts
@@ -3,11 +3,11 @@ import type { SomeReflection } from './typedoc/types';
 
 export const extractUsage = (doc: SomeReflection): Record<string, string> =>
     [doc, ...((doc as DeclarationReflection).signatures ?? [])]
-        .flatMap((signatures) => signatures.comment?.tags)
+        .flatMap((signatures) => signatures.comment?.blockTags)
         .reduce<Record<string, string>>((acc, tag) => {
-            if (!tag || tag.tagName !== 'usage') return acc;
+            if (!tag || tag.tag !== '@usage') return acc;
             return {
                 ...acc,
-                [tag.paramName ?? doc.name]: tag.text,
+                [doc.name]: tag.content.map(({ text }) => text).join('') ?? '',
             };
         }, {}) ?? {};

--- a/documentation/src/utils/typedoc/hasTag.ts
+++ b/documentation/src/utils/typedoc/hasTag.ts
@@ -1,4 +1,6 @@
 import type { Comment } from 'typedoc';
 
 export const hasTag = (doc: { comment?: Comment }, tag: string) =>
-    doc.comment?.tags?.some((t) => t.tagName === tag);
+    doc.comment?.blockTags?.some(
+        (t) => t.tag === (tag.startsWith('@') ? tag : `@${tag}`),
+    );

--- a/documentation/src/utils/typedoc/reflectionKind.ts
+++ b/documentation/src/utils/typedoc/reflectionKind.ts
@@ -45,6 +45,5 @@ export const isObjectLiteral = (d: D) =>
     (d.kind as any) === ReflectionKind.ObjectLiteral;
 export const isTypeAlias = (d: D): d is DeclarationReflection =>
     (d.kind as any) === ReflectionKind.TypeAlias;
-export const isEvent = (d: D) => (d.kind as any) === ReflectionKind.Event;
 export const isReference = (d: D) =>
     (d.kind as any) === ReflectionKind.Reference;

--- a/documentation/stencil.config.ts
+++ b/documentation/stencil.config.ts
@@ -2,8 +2,6 @@ import { Config } from '@stencil/core';
 import { postcss } from '@stencil/postcss';
 import { assetsPath } from '@eventstore-ui/assets';
 import postcssPresetEnv from 'postcss-preset-env';
-import nodePolyfills from 'rollup-plugin-node-polyfills';
-import requireContext from 'rollup-plugin-require-context';
 
 import { string } from 'rollup-plugin-string';
 import { workerPath } from '@eventstore-ui/editor/configure';
@@ -38,12 +36,7 @@ export const config: Config = {
         {
             type: 'www',
             baseUrl: 'https://design-system.eventstore.com/',
-            serviceWorker: {
-                swSrc: './src/global/sw.js',
-                globPatterns: ['**/*.{js,css,woff,woff2}'],
-                // monaco is pretty chunky, but we still want to pre-cache it
-                maximumFileSizeToCacheInBytes: 3_000_000,
-            },
+            serviceWorker: false,
             copy: [
                 ...imports,
                 {
@@ -65,9 +58,6 @@ export const config: Config = {
             ],
         },
     ],
-    commonjs: {
-        include: undefined,
-    } as any,
     devServer: {
         openBrowser: false,
         reloadStrategy: 'pageReload',
@@ -88,8 +78,4 @@ export const config: Config = {
             ],
         }),
     ],
-    rollupPlugins: {
-        before: [requireContext({ include: ['**/*.ts', '**/*.tsx'] })],
-        after: [nodePolyfills()],
-    },
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "npm-run-all": "^4.1.5",
         "nx": "15.5.1",
         "prettier": "^2.2.1",
-        "typescript": "4.5.5"
+        "typescript": "4.9.4"
     },
     "packageManager": "yarn@3.1.0"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
         "@eventstore-ui/router": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "puppeteer": "^19.5.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,11 +54,11 @@
         "@eventstore-ui/router": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
-        "puppeteer": "10.4.0",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "puppeteer": "^19.5.0",
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -22,7 +22,27 @@ import { ClickRow, JumpOptions, LoadWindow, TableCells, TableSort } from "./comp
 import { Tab } from "./components/es-tabs/types";
 import { Toast, ToastLevel, ToastOptions } from "./components/toast/types";
 import { WizardPage } from "./components/es-wizard/types";
+export { AccordianSection } from "./components/es-accordian/types";
+export { RenderFunction } from "./types";
+export { BadgeVariant } from "./components/es-badge/es-badge";
+export { ButtonVariant } from "./components/buttons/types";
+export { EsCalloutVariant } from "./components/es-callout/es-callout";
+export { IconDescription } from "./components/es-icon/types";
+export { CornerBannerVariant } from "./components/es-corner-banner/es-corner-banner";
+export { CounterColor, CounterVariant } from "./components/es-counter/es-counter";
+export { PageChangeEventType } from "./components/es-pagination/types";
+export { Constrain } from "./components/es-popover/es-popover";
+export { Placement } from "@floating-ui/dom";
+export { Checkpoint } from "./components/es-progression/es-progression";
+export { Status } from "./components/es-status/es-status";
+export { ClickRow, JumpOptions, LoadWindow, TableCells, TableSort } from "./components/tables/types";
+export { Tab } from "./components/es-tabs/types";
+export { Toast, ToastLevel, ToastOptions } from "./components/toast/types";
+export { WizardPage } from "./components/es-wizard/types";
 export namespace Components {
+    /**
+     * Optionally collapsible sectioned view. Each section can be targeted via a part.
+     */
     interface EsAccordian {
         /**
           * An array of sections to display.
@@ -39,6 +59,9 @@ export namespace Components {
         "renderNode": (node: RenderFunction) => Promise<void>;
         "showBackdrop": boolean;
     }
+    /**
+     * Display a counter or dot beside a component to indicate action being required.
+     */
     interface EsBadge {
         /**
           * Choose the color variant of the badge
@@ -61,6 +84,9 @@ export namespace Components {
          */
         "variant": BadgeVariant;
     }
+    /**
+     * A button.
+     */
     interface EsButton {
         /**
           * If the button is disabled. Prevents the user from interacting with the button: it cannot be pressed or focused.
@@ -75,6 +101,9 @@ export namespace Components {
          */
         "variant": ButtonVariant;
     }
+    /**
+     * Anchor link version of es-button, wraps a `Link` from `@eventstore-ui/router`.
+     */
     interface EsButtonLink {
         /**
           * Class for the contained anchor element
@@ -121,6 +150,9 @@ export namespace Components {
          */
         "variant": ButtonVariant;
     }
+    /**
+     * Calls out a piece of information.
+     */
     interface EsCallout {
         /**
           * Heading text.
@@ -135,12 +167,18 @@ export namespace Components {
          */
         "variant": EsCalloutVariant;
     }
+    /**
+     * Copies the text passed as a child when clicked.
+     */
     interface EsCopy {
         /**
           * Manually triggers the copy of the inner text.
          */
         "copy": () => Promise<void>;
     }
+    /**
+     * Display a banner with text in the corner.
+     */
     interface EsCornerBanner {
         /**
           * Which styling variant to use.
@@ -155,6 +193,9 @@ export namespace Components {
          */
         "y": 'top' | 'bottom';
     }
+    /**
+     * A pill display of an number, that pulses on change. Caps out at 999.
+     */
     interface EsCounter {
         /**
           * Choose the color variant of the counter
@@ -173,6 +214,10 @@ export namespace Components {
          */
         "variant": CounterVariant;
     }
+    /**
+     * Displays an icon loaded from the `iconStore`. An icon named "spinner" will automatically spin.
+     * See [IconStore](/components/variables/iconStore) for details on how to load icons.
+     */
     interface EsIcon {
         /**
           * Rotate the icon to a speciied angle.
@@ -199,8 +244,14 @@ export namespace Components {
          */
         "spinEnd": () => Promise<void>;
     }
+    /**
+     * Display a row of five pulsing dots, to indicate loading.
+     */
     interface EsLoadingDots {
     }
+    /**
+     * Displays a grey block to placehold loading text.
+     */
     interface EsLoadingText {
         /**
           * The expected loaded text length.
@@ -211,6 +262,11 @@ export namespace Components {
          */
         "variance"?: number;
     }
+    /**
+     * A pop up modal for overlaying information, warnings and confirmations.
+     * Traps focus within the modal, and returns focus to previous location when closed.
+     * Pair with an [`es-portal`](/components/components/es-portal) to open and close.
+     */
     interface EsModal {
         /**
           * If the modal should have a footer.
@@ -221,6 +277,9 @@ export namespace Components {
          */
         "header": boolean;
     }
+    /**
+     * Page navigation with ability to jump to first and last pages with `pageCount` is provided.
+     */
     interface EsPagination {
         /**
           * Current Page.
@@ -231,6 +290,9 @@ export namespace Components {
          */
         "pageCount"?: number;
     }
+    /**
+     * Attaches a portaled popover, attached to the parent node. Can be used to create dropdowns, tooltips etc. The parent scoped shadow styles are copied to the created portals shadow styles, to allow styling popover contents externally.
+     */
     interface EsPopover {
         /**
           * If the popover should render an arrow.
@@ -312,6 +374,9 @@ export namespace Components {
     }
     interface EsPopperInner {
     }
+    /**
+     * Portals the passed node to a different part of the document. Note that portal does not transfer shadow scoped styles, unlike `es-popover`, so any portaled elements should be self contained.
+     */
     interface EsPortal {
         "attachElement": () => Promise<void>;
         /**
@@ -336,6 +401,9 @@ export namespace Components {
          */
         "target": string;
     }
+    /**
+     * A wizard progression bar.
+     */
     interface EsProgression {
         /**
           * A list of checkpoints to display.
@@ -346,11 +414,17 @@ export namespace Components {
          */
         "location": string;
     }
+    /**
+     * Wraps a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to allow tracking `DOMRect` dimensions
+     */
     interface EsResizeObserver {
     }
     interface EsStatus {
         "status": Status;
     }
+    /**
+     * Create a table from data.
+     */
     interface EsTable {
         /**
           * A record of table cell definitions.
@@ -408,6 +482,9 @@ export namespace Components {
          */
         "stickyHeader": boolean;
     }
+    /**
+     * Render a single row data as a grid of information.
+     */
     interface EsTableDetail {
         /**
           * A record of table cell definitions.
@@ -426,6 +503,9 @@ export namespace Components {
          */
         "identifier": string;
     }
+    /**
+     * A default header for [`es-table-detail`](/components/components/es-table-detail).
+     */
     interface EsTableDetailHeader {
         /**
           * Which cell to place in the top right as a list of actions.
@@ -448,6 +528,9 @@ export namespace Components {
          */
         "titleCell": string;
     }
+    /**
+     * Create a nested table from data.
+     */
     interface EsTableNested {
         /**
           * A path to a the currently active row, to auto expand its parent and show it as selected.
@@ -549,6 +632,9 @@ export namespace Components {
          */
         "toggleRowOnClick": boolean;
     }
+    /**
+     * Create a virtualized table from data.
+     */
     interface EsTableVirtualized {
         /**
           * The height (in pixels) of the after
@@ -651,6 +737,9 @@ export namespace Components {
          */
         "windowSize": number;
     }
+    /**
+     * A tabbed panel. Each panel can be targeted via a slot.
+     */
     interface EsTabs {
         /**
           * The currently active panel. By default it will take from the passed activeParam, or the first tab.
@@ -665,6 +754,9 @@ export namespace Components {
          */
         "tabs": Tab[];
     }
+    /**
+     * A button with an icon that displays the state of a async action on click.
+     */
     interface EsThinkingButton {
         /**
           * The async action to be called on click.
@@ -708,6 +800,9 @@ export namespace Components {
     interface EsToaster {
         "popToast": (level: ToastLevel | undefined, { message, title, duration, icon, onClick, }: ToastOptions) => Promise<() => void>;
     }
+    /**
+     * A multi step wizard. Each step can be targeted via a slot.
+     */
     interface EsWizard {
         /**
           * The currently active page
@@ -772,6 +867,9 @@ export interface EsTabsCustomEvent<T> extends CustomEvent<T> {
     target: HTMLEsTabsElement;
 }
 declare global {
+    /**
+     * Optionally collapsible sectioned view. Each section can be targeted via a part.
+     */
     interface HTMLEsAccordianElement extends Components.EsAccordian, HTMLStencilElement {
     }
     var HTMLEsAccordianElement: {
@@ -784,78 +882,120 @@ declare global {
         prototype: HTMLEsBackdropElement;
         new (): HTMLEsBackdropElement;
     };
+    /**
+     * Display a counter or dot beside a component to indicate action being required.
+     */
     interface HTMLEsBadgeElement extends Components.EsBadge, HTMLStencilElement {
     }
     var HTMLEsBadgeElement: {
         prototype: HTMLEsBadgeElement;
         new (): HTMLEsBadgeElement;
     };
+    /**
+     * A button.
+     */
     interface HTMLEsButtonElement extends Components.EsButton, HTMLStencilElement {
     }
     var HTMLEsButtonElement: {
         prototype: HTMLEsButtonElement;
         new (): HTMLEsButtonElement;
     };
+    /**
+     * Anchor link version of es-button, wraps a `Link` from `@eventstore-ui/router`.
+     */
     interface HTMLEsButtonLinkElement extends Components.EsButtonLink, HTMLStencilElement {
     }
     var HTMLEsButtonLinkElement: {
         prototype: HTMLEsButtonLinkElement;
         new (): HTMLEsButtonLinkElement;
     };
+    /**
+     * Calls out a piece of information.
+     */
     interface HTMLEsCalloutElement extends Components.EsCallout, HTMLStencilElement {
     }
     var HTMLEsCalloutElement: {
         prototype: HTMLEsCalloutElement;
         new (): HTMLEsCalloutElement;
     };
+    /**
+     * Copies the text passed as a child when clicked.
+     */
     interface HTMLEsCopyElement extends Components.EsCopy, HTMLStencilElement {
     }
     var HTMLEsCopyElement: {
         prototype: HTMLEsCopyElement;
         new (): HTMLEsCopyElement;
     };
+    /**
+     * Display a banner with text in the corner.
+     */
     interface HTMLEsCornerBannerElement extends Components.EsCornerBanner, HTMLStencilElement {
     }
     var HTMLEsCornerBannerElement: {
         prototype: HTMLEsCornerBannerElement;
         new (): HTMLEsCornerBannerElement;
     };
+    /**
+     * A pill display of an number, that pulses on change. Caps out at 999.
+     */
     interface HTMLEsCounterElement extends Components.EsCounter, HTMLStencilElement {
     }
     var HTMLEsCounterElement: {
         prototype: HTMLEsCounterElement;
         new (): HTMLEsCounterElement;
     };
+    /**
+     * Displays an icon loaded from the `iconStore`. An icon named "spinner" will automatically spin.
+     * See [IconStore](/components/variables/iconStore) for details on how to load icons.
+     */
     interface HTMLEsIconElement extends Components.EsIcon, HTMLStencilElement {
     }
     var HTMLEsIconElement: {
         prototype: HTMLEsIconElement;
         new (): HTMLEsIconElement;
     };
+    /**
+     * Display a row of five pulsing dots, to indicate loading.
+     */
     interface HTMLEsLoadingDotsElement extends Components.EsLoadingDots, HTMLStencilElement {
     }
     var HTMLEsLoadingDotsElement: {
         prototype: HTMLEsLoadingDotsElement;
         new (): HTMLEsLoadingDotsElement;
     };
+    /**
+     * Displays a grey block to placehold loading text.
+     */
     interface HTMLEsLoadingTextElement extends Components.EsLoadingText, HTMLStencilElement {
     }
     var HTMLEsLoadingTextElement: {
         prototype: HTMLEsLoadingTextElement;
         new (): HTMLEsLoadingTextElement;
     };
+    /**
+     * A pop up modal for overlaying information, warnings and confirmations.
+     * Traps focus within the modal, and returns focus to previous location when closed.
+     * Pair with an [`es-portal`](/components/components/es-portal) to open and close.
+     */
     interface HTMLEsModalElement extends Components.EsModal, HTMLStencilElement {
     }
     var HTMLEsModalElement: {
         prototype: HTMLEsModalElement;
         new (): HTMLEsModalElement;
     };
+    /**
+     * Page navigation with ability to jump to first and last pages with `pageCount` is provided.
+     */
     interface HTMLEsPaginationElement extends Components.EsPagination, HTMLStencilElement {
     }
     var HTMLEsPaginationElement: {
         prototype: HTMLEsPaginationElement;
         new (): HTMLEsPaginationElement;
     };
+    /**
+     * Attaches a portaled popover, attached to the parent node. Can be used to create dropdowns, tooltips etc. The parent scoped shadow styles are copied to the created portals shadow styles, to allow styling popover contents externally.
+     */
     interface HTMLEsPopoverElement extends Components.EsPopover, HTMLStencilElement {
     }
     var HTMLEsPopoverElement: {
@@ -874,18 +1014,27 @@ declare global {
         prototype: HTMLEsPopperInnerElement;
         new (): HTMLEsPopperInnerElement;
     };
+    /**
+     * Portals the passed node to a different part of the document. Note that portal does not transfer shadow scoped styles, unlike `es-popover`, so any portaled elements should be self contained.
+     */
     interface HTMLEsPortalElement extends Components.EsPortal, HTMLStencilElement {
     }
     var HTMLEsPortalElement: {
         prototype: HTMLEsPortalElement;
         new (): HTMLEsPortalElement;
     };
+    /**
+     * A wizard progression bar.
+     */
     interface HTMLEsProgressionElement extends Components.EsProgression, HTMLStencilElement {
     }
     var HTMLEsProgressionElement: {
         prototype: HTMLEsProgressionElement;
         new (): HTMLEsProgressionElement;
     };
+    /**
+     * Wraps a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to allow tracking `DOMRect` dimensions
+     */
     interface HTMLEsResizeObserverElement extends Components.EsResizeObserver, HTMLStencilElement {
     }
     var HTMLEsResizeObserverElement: {
@@ -898,42 +1047,63 @@ declare global {
         prototype: HTMLEsStatusElement;
         new (): HTMLEsStatusElement;
     };
+    /**
+     * Create a table from data.
+     */
     interface HTMLEsTableElement extends Components.EsTable, HTMLStencilElement {
     }
     var HTMLEsTableElement: {
         prototype: HTMLEsTableElement;
         new (): HTMLEsTableElement;
     };
+    /**
+     * Render a single row data as a grid of information.
+     */
     interface HTMLEsTableDetailElement extends Components.EsTableDetail, HTMLStencilElement {
     }
     var HTMLEsTableDetailElement: {
         prototype: HTMLEsTableDetailElement;
         new (): HTMLEsTableDetailElement;
     };
+    /**
+     * A default header for [`es-table-detail`](/components/components/es-table-detail).
+     */
     interface HTMLEsTableDetailHeaderElement extends Components.EsTableDetailHeader, HTMLStencilElement {
     }
     var HTMLEsTableDetailHeaderElement: {
         prototype: HTMLEsTableDetailHeaderElement;
         new (): HTMLEsTableDetailHeaderElement;
     };
+    /**
+     * Create a nested table from data.
+     */
     interface HTMLEsTableNestedElement extends Components.EsTableNested, HTMLStencilElement {
     }
     var HTMLEsTableNestedElement: {
         prototype: HTMLEsTableNestedElement;
         new (): HTMLEsTableNestedElement;
     };
+    /**
+     * Create a virtualized table from data.
+     */
     interface HTMLEsTableVirtualizedElement extends Components.EsTableVirtualized, HTMLStencilElement {
     }
     var HTMLEsTableVirtualizedElement: {
         prototype: HTMLEsTableVirtualizedElement;
         new (): HTMLEsTableVirtualizedElement;
     };
+    /**
+     * A tabbed panel. Each panel can be targeted via a slot.
+     */
     interface HTMLEsTabsElement extends Components.EsTabs, HTMLStencilElement {
     }
     var HTMLEsTabsElement: {
         prototype: HTMLEsTabsElement;
         new (): HTMLEsTabsElement;
     };
+    /**
+     * A button with an icon that displays the state of a async action on click.
+     */
     interface HTMLEsThinkingButtonElement extends Components.EsThinkingButton, HTMLStencilElement {
     }
     var HTMLEsThinkingButtonElement: {
@@ -952,6 +1122,9 @@ declare global {
         prototype: HTMLEsToasterElement;
         new (): HTMLEsToasterElement;
     };
+    /**
+     * A multi step wizard. Each step can be targeted via a slot.
+     */
     interface HTMLEsWizardElement extends Components.EsWizard, HTMLStencilElement {
     }
     var HTMLEsWizardElement: {
@@ -993,6 +1166,9 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * Optionally collapsible sectioned view. Each section can be targeted via a part.
+     */
     interface EsAccordian {
         /**
           * An array of sections to display.
@@ -1009,6 +1185,9 @@ declare namespace LocalJSX {
         "preventOverscroll"?: boolean;
         "showBackdrop"?: boolean;
     }
+    /**
+     * Display a counter or dot beside a component to indicate action being required.
+     */
     interface EsBadge {
         /**
           * Choose the color variant of the badge
@@ -1031,6 +1210,9 @@ declare namespace LocalJSX {
          */
         "variant"?: BadgeVariant;
     }
+    /**
+     * A button.
+     */
     interface EsButton {
         /**
           * If the button is disabled. Prevents the user from interacting with the button: it cannot be pressed or focused.
@@ -1045,6 +1227,9 @@ declare namespace LocalJSX {
          */
         "variant"?: ButtonVariant;
     }
+    /**
+     * Anchor link version of es-button, wraps a `Link` from `@eventstore-ui/router`.
+     */
     interface EsButtonLink {
         /**
           * Class for the contained anchor element
@@ -1091,6 +1276,9 @@ declare namespace LocalJSX {
          */
         "variant"?: ButtonVariant;
     }
+    /**
+     * Calls out a piece of information.
+     */
     interface EsCallout {
         /**
           * Heading text.
@@ -1105,8 +1293,14 @@ declare namespace LocalJSX {
          */
         "variant"?: EsCalloutVariant;
     }
+    /**
+     * Copies the text passed as a child when clicked.
+     */
     interface EsCopy {
     }
+    /**
+     * Display a banner with text in the corner.
+     */
     interface EsCornerBanner {
         /**
           * Which styling variant to use.
@@ -1121,6 +1315,9 @@ declare namespace LocalJSX {
          */
         "y"?: 'top' | 'bottom';
     }
+    /**
+     * A pill display of an number, that pulses on change. Caps out at 999.
+     */
     interface EsCounter {
         /**
           * Choose the color variant of the counter
@@ -1139,6 +1336,10 @@ declare namespace LocalJSX {
          */
         "variant"?: CounterVariant;
     }
+    /**
+     * Displays an icon loaded from the `iconStore`. An icon named "spinner" will automatically spin.
+     * See [IconStore](/components/variables/iconStore) for details on how to load icons.
+     */
     interface EsIcon {
         /**
           * Rotate the icon to a speciied angle.
@@ -1161,8 +1362,14 @@ declare namespace LocalJSX {
          */
         "spinDirection"?: 'clockwise' | 'antiClockwise';
     }
+    /**
+     * Display a row of five pulsing dots, to indicate loading.
+     */
     interface EsLoadingDots {
     }
+    /**
+     * Displays a grey block to placehold loading text.
+     */
     interface EsLoadingText {
         /**
           * The expected loaded text length.
@@ -1173,6 +1380,11 @@ declare namespace LocalJSX {
          */
         "variance"?: number;
     }
+    /**
+     * A pop up modal for overlaying information, warnings and confirmations.
+     * Traps focus within the modal, and returns focus to previous location when closed.
+     * Pair with an [`es-portal`](/components/components/es-portal) to open and close.
+     */
     interface EsModal {
         /**
           * If the modal should have a footer.
@@ -1187,6 +1399,9 @@ declare namespace LocalJSX {
          */
         "onRequestClose"?: (event: EsModalCustomEvent<void>) => void;
     }
+    /**
+     * Page navigation with ability to jump to first and last pages with `pageCount` is provided.
+     */
     interface EsPagination {
         /**
           * Current Page.
@@ -1201,6 +1416,9 @@ declare namespace LocalJSX {
          */
         "pageCount"?: number;
     }
+    /**
+     * Attaches a portaled popover, attached to the parent node. Can be used to create dropdowns, tooltips etc. The parent scoped shadow styles are copied to the created portals shadow styles, to allow styling popover contents externally.
+     */
     interface EsPopover {
         /**
           * If the popover should render an arrow.
@@ -1286,6 +1504,9 @@ declare namespace LocalJSX {
     }
     interface EsPopperInner {
     }
+    /**
+     * Portals the passed node to a different part of the document. Note that portal does not transfer shadow scoped styles, unlike `es-popover`, so any portaled elements should be self contained.
+     */
     interface EsPortal {
         /**
           * If the portal should overlay a backdrop, to prevent external clicks.
@@ -1312,6 +1533,9 @@ declare namespace LocalJSX {
          */
         "target"?: string;
     }
+    /**
+     * A wizard progression bar.
+     */
     interface EsProgression {
         /**
           * A list of checkpoints to display.
@@ -1326,6 +1550,9 @@ declare namespace LocalJSX {
          */
         "onProgressionRequest"?: (event: EsProgressionCustomEvent<string>) => void;
     }
+    /**
+     * Wraps a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to allow tracking `DOMRect` dimensions
+     */
     interface EsResizeObserver {
         /**
           * Triggered when the size of the element changes.
@@ -1335,6 +1562,9 @@ declare namespace LocalJSX {
     interface EsStatus {
         "status": Status;
     }
+    /**
+     * Create a table from data.
+     */
     interface EsTable {
         /**
           * A record of table cell definitions.
@@ -1400,6 +1630,9 @@ declare namespace LocalJSX {
          */
         "stickyHeader"?: boolean;
     }
+    /**
+     * Render a single row data as a grid of information.
+     */
     interface EsTableDetail {
         /**
           * A record of table cell definitions.
@@ -1418,6 +1651,9 @@ declare namespace LocalJSX {
          */
         "identifier"?: string;
     }
+    /**
+     * A default header for [`es-table-detail`](/components/components/es-table-detail).
+     */
     interface EsTableDetailHeader {
         /**
           * Which cell to place in the top right as a list of actions.
@@ -1440,6 +1676,9 @@ declare namespace LocalJSX {
          */
         "titleCell"?: string;
     }
+    /**
+     * Create a nested table from data.
+     */
     interface EsTableNested {
         /**
           * A path to a the currently active row, to auto expand its parent and show it as selected.
@@ -1549,6 +1788,9 @@ declare namespace LocalJSX {
          */
         "toggleRowOnClick"?: boolean;
     }
+    /**
+     * Create a virtualized table from data.
+     */
     interface EsTableVirtualized {
         /**
           * The height (in pixels) of the after
@@ -1667,6 +1909,9 @@ declare namespace LocalJSX {
          */
         "windowSize"?: number;
     }
+    /**
+     * A tabbed panel. Each panel can be targeted via a slot.
+     */
     interface EsTabs {
         /**
           * The currently active panel. By default it will take from the passed activeParam, or the first tab.
@@ -1685,6 +1930,9 @@ declare namespace LocalJSX {
          */
         "tabs": Tab[];
     }
+    /**
+     * A button with an icon that displays the state of a async action on click.
+     */
     interface EsThinkingButton {
         /**
           * The async action to be called on click.
@@ -1726,6 +1974,9 @@ declare namespace LocalJSX {
     }
     interface EsToaster {
     }
+    /**
+     * A multi step wizard. Each step can be targeted via a slot.
+     */
     interface EsWizard {
         /**
           * The currently active page
@@ -1778,36 +2029,114 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * Optionally collapsible sectioned view. Each section can be targeted via a part.
+             */
             "es-accordian": LocalJSX.EsAccordian & JSXBase.HTMLAttributes<HTMLEsAccordianElement>;
             "es-backdrop": LocalJSX.EsBackdrop & JSXBase.HTMLAttributes<HTMLEsBackdropElement>;
+            /**
+             * Display a counter or dot beside a component to indicate action being required.
+             */
             "es-badge": LocalJSX.EsBadge & JSXBase.HTMLAttributes<HTMLEsBadgeElement>;
+            /**
+             * A button.
+             */
             "es-button": LocalJSX.EsButton & JSXBase.HTMLAttributes<HTMLEsButtonElement>;
+            /**
+             * Anchor link version of es-button, wraps a `Link` from `@eventstore-ui/router`.
+             */
             "es-button-link": LocalJSX.EsButtonLink & JSXBase.HTMLAttributes<HTMLEsButtonLinkElement>;
+            /**
+             * Calls out a piece of information.
+             */
             "es-callout": LocalJSX.EsCallout & JSXBase.HTMLAttributes<HTMLEsCalloutElement>;
+            /**
+             * Copies the text passed as a child when clicked.
+             */
             "es-copy": LocalJSX.EsCopy & JSXBase.HTMLAttributes<HTMLEsCopyElement>;
+            /**
+             * Display a banner with text in the corner.
+             */
             "es-corner-banner": LocalJSX.EsCornerBanner & JSXBase.HTMLAttributes<HTMLEsCornerBannerElement>;
+            /**
+             * A pill display of an number, that pulses on change. Caps out at 999.
+             */
             "es-counter": LocalJSX.EsCounter & JSXBase.HTMLAttributes<HTMLEsCounterElement>;
+            /**
+             * Displays an icon loaded from the `iconStore`. An icon named "spinner" will automatically spin.
+             * See [IconStore](/components/variables/iconStore) for details on how to load icons.
+             */
             "es-icon": LocalJSX.EsIcon & JSXBase.HTMLAttributes<HTMLEsIconElement>;
+            /**
+             * Display a row of five pulsing dots, to indicate loading.
+             */
             "es-loading-dots": LocalJSX.EsLoadingDots & JSXBase.HTMLAttributes<HTMLEsLoadingDotsElement>;
+            /**
+             * Displays a grey block to placehold loading text.
+             */
             "es-loading-text": LocalJSX.EsLoadingText & JSXBase.HTMLAttributes<HTMLEsLoadingTextElement>;
+            /**
+             * A pop up modal for overlaying information, warnings and confirmations.
+             * Traps focus within the modal, and returns focus to previous location when closed.
+             * Pair with an [`es-portal`](/components/components/es-portal) to open and close.
+             */
             "es-modal": LocalJSX.EsModal & JSXBase.HTMLAttributes<HTMLEsModalElement>;
+            /**
+             * Page navigation with ability to jump to first and last pages with `pageCount` is provided.
+             */
             "es-pagination": LocalJSX.EsPagination & JSXBase.HTMLAttributes<HTMLEsPaginationElement>;
+            /**
+             * Attaches a portaled popover, attached to the parent node. Can be used to create dropdowns, tooltips etc. The parent scoped shadow styles are copied to the created portals shadow styles, to allow styling popover contents externally.
+             */
             "es-popover": LocalJSX.EsPopover & JSXBase.HTMLAttributes<HTMLEsPopoverElement>;
             "es-popper": LocalJSX.EsPopper & JSXBase.HTMLAttributes<HTMLEsPopperElement>;
             "es-popper-inner": LocalJSX.EsPopperInner & JSXBase.HTMLAttributes<HTMLEsPopperInnerElement>;
+            /**
+             * Portals the passed node to a different part of the document. Note that portal does not transfer shadow scoped styles, unlike `es-popover`, so any portaled elements should be self contained.
+             */
             "es-portal": LocalJSX.EsPortal & JSXBase.HTMLAttributes<HTMLEsPortalElement>;
+            /**
+             * A wizard progression bar.
+             */
             "es-progression": LocalJSX.EsProgression & JSXBase.HTMLAttributes<HTMLEsProgressionElement>;
+            /**
+             * Wraps a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to allow tracking `DOMRect` dimensions
+             */
             "es-resize-observer": LocalJSX.EsResizeObserver & JSXBase.HTMLAttributes<HTMLEsResizeObserverElement>;
             "es-status": LocalJSX.EsStatus & JSXBase.HTMLAttributes<HTMLEsStatusElement>;
+            /**
+             * Create a table from data.
+             */
             "es-table": LocalJSX.EsTable & JSXBase.HTMLAttributes<HTMLEsTableElement>;
+            /**
+             * Render a single row data as a grid of information.
+             */
             "es-table-detail": LocalJSX.EsTableDetail & JSXBase.HTMLAttributes<HTMLEsTableDetailElement>;
+            /**
+             * A default header for [`es-table-detail`](/components/components/es-table-detail).
+             */
             "es-table-detail-header": LocalJSX.EsTableDetailHeader & JSXBase.HTMLAttributes<HTMLEsTableDetailHeaderElement>;
+            /**
+             * Create a nested table from data.
+             */
             "es-table-nested": LocalJSX.EsTableNested & JSXBase.HTMLAttributes<HTMLEsTableNestedElement>;
+            /**
+             * Create a virtualized table from data.
+             */
             "es-table-virtualized": LocalJSX.EsTableVirtualized & JSXBase.HTMLAttributes<HTMLEsTableVirtualizedElement>;
+            /**
+             * A tabbed panel. Each panel can be targeted via a slot.
+             */
             "es-tabs": LocalJSX.EsTabs & JSXBase.HTMLAttributes<HTMLEsTabsElement>;
+            /**
+             * A button with an icon that displays the state of a async action on click.
+             */
             "es-thinking-button": LocalJSX.EsThinkingButton & JSXBase.HTMLAttributes<HTMLEsThinkingButtonElement>;
             "es-toast": LocalJSX.EsToast & JSXBase.HTMLAttributes<HTMLEsToastElement>;
             "es-toaster": LocalJSX.EsToaster & JSXBase.HTMLAttributes<HTMLEsToasterElement>;
+            /**
+             * A multi step wizard. Each step can be targeted via a slot.
+             */
             "es-wizard": LocalJSX.EsWizard & JSXBase.HTMLAttributes<HTMLEsWizardElement>;
         }
     }

--- a/packages/components/src/components/buttons/es-button-link/readme.md
+++ b/packages/components/src/components/buttons/es-button-link/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Anchor link version of es-button, wraps a `Link` from `@eventstore-ui/router`.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/buttons/es-button/readme.md
+++ b/packages/components/src/components/buttons/es-button/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A button.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-accordian/readme.md
+++ b/packages/components/src/components/es-accordian/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Optionally collapsible sectioned view. Each section can be targeted via a part.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-badge/readme.md
+++ b/packages/components/src/components/es-badge/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Display a counter or dot beside a component to indicate action being required.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-callout/readme.md
+++ b/packages/components/src/components/es-callout/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Calls out a piece of information.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-copy/readme.md
+++ b/packages/components/src/components/es-copy/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Copies the text passed as a child when clicked.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-corner-banner/readme.md
+++ b/packages/components/src/components/es-corner-banner/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Display a banner with text in the corner.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-counter/readme.md
+++ b/packages/components/src/components/es-counter/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A pill display of an number, that pulses on change. Caps out at 999.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-icon/readme.md
+++ b/packages/components/src/components/es-icon/readme.md
@@ -5,6 +5,11 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays an icon loaded from the `iconStore`. An icon named "spinner" will automatically spin.
+See [IconStore](/components/variables/iconStore) for details on how to load icons.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-loading-dots/readme.md
+++ b/packages/components/src/components/es-loading-dots/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Display a row of five pulsing dots, to indicate loading.
+
 ## Dependencies
 
 ### Depends on

--- a/packages/components/src/components/es-loading-text/readme.md
+++ b/packages/components/src/components/es-loading-text/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays a grey block to placehold loading text.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-modal/readme.md
+++ b/packages/components/src/components/es-modal/readme.md
@@ -3,6 +3,12 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A pop up modal for overlaying information, warnings and confirmations.
+Traps focus within the modal, and returns focus to previous location when closed.
+Pair with an [`es-portal`](/components/components/es-portal) to open and close.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-pagination/readme.md
+++ b/packages/components/src/components/es-pagination/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Page navigation with ability to jump to first and last pages with `pageCount` is provided.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-popover/readme.md
+++ b/packages/components/src/components/es-popover/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Attaches a portaled popover, attached to the parent node. Can be used to create dropdowns, tooltips etc. The parent scoped shadow styles are copied to the created portals shadow styles, to allow styling popover contents externally.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-portal/readme.md
+++ b/packages/components/src/components/es-portal/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Portals the passed node to a different part of the document. Note that portal does not transfer shadow scoped styles, unlike `es-popover`, so any portaled elements should be self contained.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-progression/readme.md
+++ b/packages/components/src/components/es-progression/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A wizard progression bar.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-resize-observer/readme.md
+++ b/packages/components/src/components/es-resize-observer/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Wraps a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to allow tracking `DOMRect` dimensions
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-tabs/readme.md
+++ b/packages/components/src/components/es-tabs/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A tabbed panel. Each panel can be targeted via a slot.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-thinking-button/readme.md
+++ b/packages/components/src/components/es-thinking-button/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A button with an icon that displays the state of a async action on click.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/es-wizard/readme.md
+++ b/packages/components/src/components/es-wizard/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A multi step wizard. Each step can be targeted via a slot.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/tables/es-table-detail-header/readme.md
+++ b/packages/components/src/components/tables/es-table-detail-header/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A default header for [`es-table-detail`](/components/components/es-table-detail).
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/tables/es-table-detail/readme.md
+++ b/packages/components/src/components/tables/es-table-detail/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Render a single row data as a grid of information.
+
 ## Usage
 
 ### Example

--- a/packages/components/src/components/tables/es-table-nested/readme.md
+++ b/packages/components/src/components/tables/es-table-nested/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Create a nested table from data.
+
 ## Properties
 
 | Property              | Attribute                | Description                                                                                                                                                                                                                                                                                           | Type                                                                        | Default                   |

--- a/packages/components/src/components/tables/es-table-virtualized/readme.md
+++ b/packages/components/src/components/tables/es-table-virtualized/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Create a virtualized table from data.
+
 ## Properties
 
 | Property                   | Attribute         | Description                                                                                                             | Type                                                                                       | Default               |

--- a/packages/components/src/components/tables/es-table/readme.md
+++ b/packages/components/src/components/tables/es-table/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Create a table from data.
+
 ## Usage
 
 ### Example

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -80,12 +80,12 @@
         "@eventstore-ui/configs": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
-        "puppeteer": "10.4.0",
+        "puppeteer": "^19.5.0",
         "rollup": "2.33.1",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -84,7 +84,7 @@
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "puppeteer": "^19.5.0",
-        "rollup": "2.33.1",
+        "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
     }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -80,7 +80,7 @@
         "@eventstore-ui/configs": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "puppeteer": "^19.5.0",

--- a/packages/editor/src/components.d.ts
+++ b/packages/editor/src/components.d.ts
@@ -6,7 +6,11 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { editor } from "monaco-editor";
+export { editor } from "monaco-editor";
 export namespace Components {
+    /**
+     * Monaco editor wrapped in a web component. Handles re-layout on container resize
+     */
     interface EsEditor {
         /**
           * An optional callback for getting a reference to the editor, for external control.
@@ -19,6 +23,9 @@ export namespace Components {
     }
 }
 declare global {
+    /**
+     * Monaco editor wrapped in a web component. Handles re-layout on container resize
+     */
     interface HTMLEsEditorElement extends Components.EsEditor, HTMLStencilElement {
     }
     var HTMLEsEditorElement: {
@@ -30,6 +37,9 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * Monaco editor wrapped in a web component. Handles re-layout on container resize
+     */
     interface EsEditor {
         /**
           * An optional callback for getting a reference to the editor, for external control.
@@ -48,6 +58,9 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * Monaco editor wrapped in a web component. Handles re-layout on container resize
+             */
             "es-editor": LocalJSX.EsEditor & JSXBase.HTMLAttributes<HTMLEsEditorElement>;
         }
     }

--- a/packages/editor/src/es-editor/readme.md
+++ b/packages/editor/src/es-editor/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Monaco editor wrapped in a web component. Handles re-layout on container resize
+
 ## Usage
 
 ### Example

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -54,11 +54,11 @@
         "@eventstore-ui/icon-manager": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
-        "puppeteer": "10.4.0",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "puppeteer": "^19.5.0",
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -54,7 +54,7 @@
         "@eventstore-ui/icon-manager": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "puppeteer": "^19.5.0",

--- a/packages/fields/src/components.d.ts
+++ b/packages/fields/src/components.d.ts
@@ -11,7 +11,16 @@ import { MaskOptions } from "./components/es-input/types";
 import { OptionFilter, RenderTypeaheadField, RenderTypeaheadOption, TypeaheadOption } from "./components/es-typeahead/types";
 import { RadioCardGroupOption, RenderCard } from "./components/es-radio-card-group/types";
 import { RenderSelectValue } from "./components/es-select/types";
+export { IconDescription } from "@eventstore-ui/components";
+export { FieldChange, RenderFunction, ValidationMessages } from "./types";
+export { MaskOptions } from "./components/es-input/types";
+export { OptionFilter, RenderTypeaheadField, RenderTypeaheadOption, TypeaheadOption } from "./components/es-typeahead/types";
+export { RadioCardGroupOption, RenderCard } from "./components/es-radio-card-group/types";
+export { RenderSelectValue } from "./components/es-select/types";
 export namespace Components {
+    /**
+     * A checkbox component
+     */
     interface EsCheckbox {
         /**
           * If the field is disabled.
@@ -38,6 +47,9 @@ export namespace Components {
          */
         "value": boolean;
     }
+    /**
+     * An optionally masked text input.
+     */
     interface EsInput {
         /**
           * If the field is disabled.
@@ -80,6 +92,9 @@ export namespace Components {
          */
         "value": string;
     }
+    /**
+     * A list creator input.
+     */
     interface EsInputList {
         /**
           * Icon for the add item button.
@@ -118,6 +133,9 @@ export namespace Components {
          */
         "value": string[];
     }
+    /**
+     * A list creator input.
+     */
     interface EsListCreator {
         /**
           * The icon to display next to the field
@@ -164,6 +182,9 @@ export namespace Components {
          */
         "value": string[];
     }
+    /**
+     * An extra large input.
+     */
     interface EsMegaInput {
         /**
           * If the field is disabled.
@@ -202,6 +223,9 @@ export namespace Components {
          */
         "value": string;
     }
+    /**
+     * A number based input. Values should be passed around as strings, as numbers can round / floating point / overflow etc if a number type is used.
+     */
     interface EsNumberInput {
         /**
           * If the field is disabled.
@@ -244,6 +268,9 @@ export namespace Components {
          */
         "value": string;
     }
+    /**
+     * A card based single select input.
+     */
     interface EsRadioCardGroup {
         /**
           * Group the cards by a key.
@@ -282,6 +309,9 @@ export namespace Components {
          */
         "value": string | null;
     }
+    /**
+     * A searchable select dropdown.
+     */
     interface EsSelect {
         /**
           * Icon to use as a chevron.
@@ -340,6 +370,9 @@ export namespace Components {
          */
         "value": string | null;
     }
+    /**
+     * A switchable switch.
+     */
     interface EsSwitch {
         /**
           * Icon to display when switch is on in high contrast mode.
@@ -382,6 +415,9 @@ export namespace Components {
          */
         "value": boolean;
     }
+    /**
+     * A textarea field.
+     */
     interface EsTextarea {
         /**
           * If the field is disabled.
@@ -433,6 +469,9 @@ export namespace Components {
         "value": string[];
         "zIndex": number;
     }
+    /**
+     * Display messages under fields.
+     */
     interface EsValidationMessages {
         /**
           * Icon to diplay next to errors. (if `showIcons` or high contrast)
@@ -501,60 +540,90 @@ export interface EsTypeaheadCustomEvent<T> extends CustomEvent<T> {
     target: HTMLEsTypeaheadElement;
 }
 declare global {
+    /**
+     * A checkbox component
+     */
     interface HTMLEsCheckboxElement extends Components.EsCheckbox, HTMLStencilElement {
     }
     var HTMLEsCheckboxElement: {
         prototype: HTMLEsCheckboxElement;
         new (): HTMLEsCheckboxElement;
     };
+    /**
+     * An optionally masked text input.
+     */
     interface HTMLEsInputElement extends Components.EsInput, HTMLStencilElement {
     }
     var HTMLEsInputElement: {
         prototype: HTMLEsInputElement;
         new (): HTMLEsInputElement;
     };
+    /**
+     * A list creator input.
+     */
     interface HTMLEsInputListElement extends Components.EsInputList, HTMLStencilElement {
     }
     var HTMLEsInputListElement: {
         prototype: HTMLEsInputListElement;
         new (): HTMLEsInputListElement;
     };
+    /**
+     * A list creator input.
+     */
     interface HTMLEsListCreatorElement extends Components.EsListCreator, HTMLStencilElement {
     }
     var HTMLEsListCreatorElement: {
         prototype: HTMLEsListCreatorElement;
         new (): HTMLEsListCreatorElement;
     };
+    /**
+     * An extra large input.
+     */
     interface HTMLEsMegaInputElement extends Components.EsMegaInput, HTMLStencilElement {
     }
     var HTMLEsMegaInputElement: {
         prototype: HTMLEsMegaInputElement;
         new (): HTMLEsMegaInputElement;
     };
+    /**
+     * A number based input. Values should be passed around as strings, as numbers can round / floating point / overflow etc if a number type is used.
+     */
     interface HTMLEsNumberInputElement extends Components.EsNumberInput, HTMLStencilElement {
     }
     var HTMLEsNumberInputElement: {
         prototype: HTMLEsNumberInputElement;
         new (): HTMLEsNumberInputElement;
     };
+    /**
+     * A card based single select input.
+     */
     interface HTMLEsRadioCardGroupElement extends Components.EsRadioCardGroup, HTMLStencilElement {
     }
     var HTMLEsRadioCardGroupElement: {
         prototype: HTMLEsRadioCardGroupElement;
         new (): HTMLEsRadioCardGroupElement;
     };
+    /**
+     * A searchable select dropdown.
+     */
     interface HTMLEsSelectElement extends Components.EsSelect, HTMLStencilElement {
     }
     var HTMLEsSelectElement: {
         prototype: HTMLEsSelectElement;
         new (): HTMLEsSelectElement;
     };
+    /**
+     * A switchable switch.
+     */
     interface HTMLEsSwitchElement extends Components.EsSwitch, HTMLStencilElement {
     }
     var HTMLEsSwitchElement: {
         prototype: HTMLEsSwitchElement;
         new (): HTMLEsSwitchElement;
     };
+    /**
+     * A textarea field.
+     */
     interface HTMLEsTextareaElement extends Components.EsTextarea, HTMLStencilElement {
     }
     var HTMLEsTextareaElement: {
@@ -567,6 +636,9 @@ declare global {
         prototype: HTMLEsTypeaheadElement;
         new (): HTMLEsTypeaheadElement;
     };
+    /**
+     * Display messages under fields.
+     */
     interface HTMLEsValidationMessagesElement extends Components.EsValidationMessages, HTMLStencilElement {
     }
     var HTMLEsValidationMessagesElement: {
@@ -589,6 +661,9 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * A checkbox component
+     */
     interface EsCheckbox {
         /**
           * If the field is disabled.
@@ -619,6 +694,9 @@ declare namespace LocalJSX {
          */
         "value": boolean;
     }
+    /**
+     * An optionally masked text input.
+     */
     interface EsInput {
         /**
           * If the field is disabled.
@@ -669,6 +747,9 @@ declare namespace LocalJSX {
          */
         "value": string;
     }
+    /**
+     * A list creator input.
+     */
     interface EsInputList {
         /**
           * Icon for the add item button.
@@ -711,6 +792,9 @@ declare namespace LocalJSX {
          */
         "value": string[];
     }
+    /**
+     * A list creator input.
+     */
     interface EsListCreator {
         /**
           * The icon to display next to the field
@@ -761,6 +845,9 @@ declare namespace LocalJSX {
          */
         "value": string[];
     }
+    /**
+     * An extra large input.
+     */
     interface EsMegaInput {
         /**
           * If the field is disabled.
@@ -807,6 +894,9 @@ declare namespace LocalJSX {
          */
         "value": string;
     }
+    /**
+     * A number based input. Values should be passed around as strings, as numbers can round / floating point / overflow etc if a number type is used.
+     */
     interface EsNumberInput {
         /**
           * If the field is disabled.
@@ -857,6 +947,9 @@ declare namespace LocalJSX {
          */
         "value": string;
     }
+    /**
+     * A card based single select input.
+     */
     interface EsRadioCardGroup {
         /**
           * Group the cards by a key.
@@ -899,6 +992,9 @@ declare namespace LocalJSX {
          */
         "value": string | null;
     }
+    /**
+     * A searchable select dropdown.
+     */
     interface EsSelect {
         /**
           * Icon to use as a chevron.
@@ -961,6 +1057,9 @@ declare namespace LocalJSX {
          */
         "value": string | null;
     }
+    /**
+     * A switchable switch.
+     */
     interface EsSwitch {
         /**
           * Icon to display when switch is on in high contrast mode.
@@ -1003,6 +1102,9 @@ declare namespace LocalJSX {
          */
         "value": boolean;
     }
+    /**
+     * A textarea field.
+     */
     interface EsTextarea {
         /**
           * If the field is disabled.
@@ -1060,6 +1162,9 @@ declare namespace LocalJSX {
         "value": string[];
         "zIndex"?: number;
     }
+    /**
+     * Display messages under fields.
+     */
     interface EsValidationMessages {
         /**
           * Icon to diplay next to errors. (if `showIcons` or high contrast)
@@ -1101,17 +1206,50 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * A checkbox component
+             */
             "es-checkbox": LocalJSX.EsCheckbox & JSXBase.HTMLAttributes<HTMLEsCheckboxElement>;
+            /**
+             * An optionally masked text input.
+             */
             "es-input": LocalJSX.EsInput & JSXBase.HTMLAttributes<HTMLEsInputElement>;
+            /**
+             * A list creator input.
+             */
             "es-input-list": LocalJSX.EsInputList & JSXBase.HTMLAttributes<HTMLEsInputListElement>;
+            /**
+             * A list creator input.
+             */
             "es-list-creator": LocalJSX.EsListCreator & JSXBase.HTMLAttributes<HTMLEsListCreatorElement>;
+            /**
+             * An extra large input.
+             */
             "es-mega-input": LocalJSX.EsMegaInput & JSXBase.HTMLAttributes<HTMLEsMegaInputElement>;
+            /**
+             * A number based input. Values should be passed around as strings, as numbers can round / floating point / overflow etc if a number type is used.
+             */
             "es-number-input": LocalJSX.EsNumberInput & JSXBase.HTMLAttributes<HTMLEsNumberInputElement>;
+            /**
+             * A card based single select input.
+             */
             "es-radio-card-group": LocalJSX.EsRadioCardGroup & JSXBase.HTMLAttributes<HTMLEsRadioCardGroupElement>;
+            /**
+             * A searchable select dropdown.
+             */
             "es-select": LocalJSX.EsSelect & JSXBase.HTMLAttributes<HTMLEsSelectElement>;
+            /**
+             * A switchable switch.
+             */
             "es-switch": LocalJSX.EsSwitch & JSXBase.HTMLAttributes<HTMLEsSwitchElement>;
+            /**
+             * A textarea field.
+             */
             "es-textarea": LocalJSX.EsTextarea & JSXBase.HTMLAttributes<HTMLEsTextareaElement>;
             "es-typeahead": LocalJSX.EsTypeahead & JSXBase.HTMLAttributes<HTMLEsTypeaheadElement>;
+            /**
+             * Display messages under fields.
+             */
             "es-validation-messages": LocalJSX.EsValidationMessages & JSXBase.HTMLAttributes<HTMLEsValidationMessagesElement>;
         }
     }

--- a/packages/fields/src/components/es-checkbox/readme.md
+++ b/packages/fields/src/components/es-checkbox/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A checkbox component
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-input-list/readme.md
+++ b/packages/fields/src/components/es-input-list/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A list creator input.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-input/readme.md
+++ b/packages/fields/src/components/es-input/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+An optionally masked text input.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-list-creator/readme.md
+++ b/packages/fields/src/components/es-list-creator/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A list creator input.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-mega-input/readme.md
+++ b/packages/fields/src/components/es-mega-input/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+An extra large input.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-number-input/readme.md
+++ b/packages/fields/src/components/es-number-input/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A number based input. Values should be passed around as strings, as numbers can round / floating point / overflow etc if a number type is used.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-radio-card-group/readme.md
+++ b/packages/fields/src/components/es-radio-card-group/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A card based single select input.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-select/readme.md
+++ b/packages/fields/src/components/es-select/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A searchable select dropdown.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-switch/readme.md
+++ b/packages/fields/src/components/es-switch/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A switchable switch.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-textarea/readme.md
+++ b/packages/fields/src/components/es-textarea/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A textarea field.
+
 ## Usage
 
 ### Example

--- a/packages/fields/src/components/es-validation-messages/readme.md
+++ b/packages/fields/src/components/es-validation-messages/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Display messages under fields.
+
 ## Usage
 
 ### Example

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -43,12 +43,12 @@
         "@eventstore-ui/components": "workspace:*",
         "@eventstore-ui/stores": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "@types/jest": "^27.0.3",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.52.7",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -45,7 +45,7 @@
         "@eventstore-ui/components": "workspace:*",
         "@eventstore-ui/stores": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "@types/jest": "^27.0.3",
         "babel-jest": "^27.5.1",
         "jest": "^27.4.5",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -21,8 +21,7 @@
         "build:rollup": "rollup -c rollup.config.js",
         "build:cleanup": "rm -rf ./build",
         "docs": "typedoc --logLevel Error --json ../../documentation/generated/forms.typedoc.json",
-        "test": "stencil test --spec",
-        "test.watch": "stencil test --spec --watchAll",
+        "test": "jest --testEnvironment jsdom --passWithNoTests",
         "lint": "yarn g:lint"
     },
     "nx": {
@@ -40,15 +39,32 @@
         "@eventstore-ui/utils": "0.1.x"
     },
     "devDependencies": {
+        "@babel/core": "^7.12.10",
+        "@babel/preset-env": "^7.12.11",
+        "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/components": "workspace:*",
         "@eventstore-ui/stores": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
         "@stencil/core": "3.0.0",
         "@types/jest": "^27.0.3",
+        "babel-jest": "^27.5.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
+    },
+    "babel": {
+        "presets": [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "current"
+                    }
+                }
+            ],
+            "@babel/preset-typescript"
+        ]
     }
 }

--- a/packages/forms/src/stores/createValidatedForm.ts
+++ b/packages/forms/src/stores/createValidatedForm.ts
@@ -72,7 +72,9 @@ export const createValidatedForm = <T extends object>(
         index?: number,
     ) => {
         if (!messages[key]) {
-            logger.warn(`Unknown key "${key}" passed to validation failure`);
+            logger.warn(
+                `Unknown key "${String(key)}" passed to validation failure`,
+            );
             return;
         }
 
@@ -203,7 +205,7 @@ export const createValidatedForm = <T extends object>(
         const { name, value } = e.detail;
 
         if (!fields.has(name)) {
-            logger.warn(`Unknown event "${name}" passed to listen`);
+            logger.warn(`Unknown event "${String(name)}" passed to listen`);
             return;
         }
 
@@ -508,7 +510,9 @@ export const createValidatedForm = <T extends object>(
                 const field = fields.get(key);
 
                 if (!field) {
-                    logger.warn(`Unknown key "${key}" passed to extend`);
+                    logger.warn(
+                        `Unknown key "${String(key)}" passed to extend`,
+                    );
                     continue;
                 }
 

--- a/packages/forms/src/utils/createStores.ts
+++ b/packages/forms/src/utils/createStores.ts
@@ -89,7 +89,7 @@ export const createStores = <T>(
 
     return {
         children,
-        dataStore: createStore<T>(initialValues as any),
+        dataStore: createStore(initialValues as any),
         messageStore: createStore<MessageStore<T>>(messages as any),
         state: createStore<ValidatedFormState>(defaultState),
         fields: fields as any,

--- a/packages/illustrations/package.json
+++ b/packages/illustrations/package.json
@@ -43,15 +43,15 @@
     },
     "devDependencies": {
         "@eventstore-ui/theme": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "case-anything": "^2.1.10",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.2.1",
-        "puppeteer": "10.4.0",
+        "puppeteer": "^19.5.0",
         "svgo": "^2.8.0",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5",
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4",
         "yargs": "^15.3.1"
     }
 }

--- a/packages/illustrations/package.json
+++ b/packages/illustrations/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@eventstore-ui/theme": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "case-anything": "^2.1.10",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",

--- a/packages/illustrations/src/components.d.ts
+++ b/packages/illustrations/src/components.d.ts
@@ -6,186 +6,324 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
+    /**
+     * Displays Backups illustration.
+     */
     interface EsIllustrationBackups {
     }
+    /**
+     * Displays Building Orgs illustration.
+     */
     interface EsIllustrationBuildingOrgs {
     }
+    /**
+     * Displays Cloud Folder illustration.
+     */
     interface EsIllustrationCloudFolder {
     }
+    /**
+     * Displays Cluster illustration.
+     */
     interface EsIllustrationCluster {
     }
+    /**
+     * Displays Es Database illustration.
+     */
     interface EsIllustrationEsDatabase {
     }
+    /**
+     * Displays Event illustration.
+     */
     interface EsIllustrationEvent {
     }
+    /**
+     * Displays Group illustration.
+     */
     interface EsIllustrationGroup {
     }
+    /**
+     * Displays Harddrive illustration.
+     */
     interface EsIllustrationHarddrive {
     }
+    /**
+     * Displays Integration illustration.
+     */
     interface EsIllustrationIntegration {
     }
+    /**
+     * Displays Issues illustration.
+     */
     interface EsIllustrationIssues {
     }
+    /**
+     * Displays Laptop illustration.
+     */
     interface EsIllustrationLaptop {
     }
+    /**
+     * Displays Network illustration.
+     */
     interface EsIllustrationNetwork {
     }
+    /**
+     * Displays Notifications illustration.
+     */
     interface EsIllustrationNotifications {
     }
+    /**
+     * Displays Peering illustration.
+     */
     interface EsIllustrationPeering {
     }
+    /**
+     * Displays Pending Member illustration.
+     */
     interface EsIllustrationPendingMember {
     }
+    /**
+     * Displays Policy illustration.
+     */
     interface EsIllustrationPolicy {
     }
+    /**
+     * Displays Poo illustration.
+     */
     interface EsIllustrationPoo {
     }
+    /**
+     * Displays Rain Cloud illustration.
+     */
     interface EsIllustrationRainCloud {
     }
+    /**
+     * Displays Role illustration.
+     */
     interface EsIllustrationRole {
     }
+    /**
+     * Displays Scheduled Backups illustration.
+     */
     interface EsIllustrationScheduledBackups {
     }
+    /**
+     * Displays Stream illustration.
+     */
     interface EsIllustrationStream {
     }
+    /**
+     * Displays Token illustration.
+     */
     interface EsIllustrationToken {
     }
+    /**
+     * Displays Welcome illustration.
+     */
     interface EsIllustrationWelcome {
     }
 }
 declare global {
+    /**
+     * Displays Backups illustration.
+     */
     interface HTMLEsIllustrationBackupsElement extends Components.EsIllustrationBackups, HTMLStencilElement {
     }
     var HTMLEsIllustrationBackupsElement: {
         prototype: HTMLEsIllustrationBackupsElement;
         new (): HTMLEsIllustrationBackupsElement;
     };
+    /**
+     * Displays Building Orgs illustration.
+     */
     interface HTMLEsIllustrationBuildingOrgsElement extends Components.EsIllustrationBuildingOrgs, HTMLStencilElement {
     }
     var HTMLEsIllustrationBuildingOrgsElement: {
         prototype: HTMLEsIllustrationBuildingOrgsElement;
         new (): HTMLEsIllustrationBuildingOrgsElement;
     };
+    /**
+     * Displays Cloud Folder illustration.
+     */
     interface HTMLEsIllustrationCloudFolderElement extends Components.EsIllustrationCloudFolder, HTMLStencilElement {
     }
     var HTMLEsIllustrationCloudFolderElement: {
         prototype: HTMLEsIllustrationCloudFolderElement;
         new (): HTMLEsIllustrationCloudFolderElement;
     };
+    /**
+     * Displays Cluster illustration.
+     */
     interface HTMLEsIllustrationClusterElement extends Components.EsIllustrationCluster, HTMLStencilElement {
     }
     var HTMLEsIllustrationClusterElement: {
         prototype: HTMLEsIllustrationClusterElement;
         new (): HTMLEsIllustrationClusterElement;
     };
+    /**
+     * Displays Es Database illustration.
+     */
     interface HTMLEsIllustrationEsDatabaseElement extends Components.EsIllustrationEsDatabase, HTMLStencilElement {
     }
     var HTMLEsIllustrationEsDatabaseElement: {
         prototype: HTMLEsIllustrationEsDatabaseElement;
         new (): HTMLEsIllustrationEsDatabaseElement;
     };
+    /**
+     * Displays Event illustration.
+     */
     interface HTMLEsIllustrationEventElement extends Components.EsIllustrationEvent, HTMLStencilElement {
     }
     var HTMLEsIllustrationEventElement: {
         prototype: HTMLEsIllustrationEventElement;
         new (): HTMLEsIllustrationEventElement;
     };
+    /**
+     * Displays Group illustration.
+     */
     interface HTMLEsIllustrationGroupElement extends Components.EsIllustrationGroup, HTMLStencilElement {
     }
     var HTMLEsIllustrationGroupElement: {
         prototype: HTMLEsIllustrationGroupElement;
         new (): HTMLEsIllustrationGroupElement;
     };
+    /**
+     * Displays Harddrive illustration.
+     */
     interface HTMLEsIllustrationHarddriveElement extends Components.EsIllustrationHarddrive, HTMLStencilElement {
     }
     var HTMLEsIllustrationHarddriveElement: {
         prototype: HTMLEsIllustrationHarddriveElement;
         new (): HTMLEsIllustrationHarddriveElement;
     };
+    /**
+     * Displays Integration illustration.
+     */
     interface HTMLEsIllustrationIntegrationElement extends Components.EsIllustrationIntegration, HTMLStencilElement {
     }
     var HTMLEsIllustrationIntegrationElement: {
         prototype: HTMLEsIllustrationIntegrationElement;
         new (): HTMLEsIllustrationIntegrationElement;
     };
+    /**
+     * Displays Issues illustration.
+     */
     interface HTMLEsIllustrationIssuesElement extends Components.EsIllustrationIssues, HTMLStencilElement {
     }
     var HTMLEsIllustrationIssuesElement: {
         prototype: HTMLEsIllustrationIssuesElement;
         new (): HTMLEsIllustrationIssuesElement;
     };
+    /**
+     * Displays Laptop illustration.
+     */
     interface HTMLEsIllustrationLaptopElement extends Components.EsIllustrationLaptop, HTMLStencilElement {
     }
     var HTMLEsIllustrationLaptopElement: {
         prototype: HTMLEsIllustrationLaptopElement;
         new (): HTMLEsIllustrationLaptopElement;
     };
+    /**
+     * Displays Network illustration.
+     */
     interface HTMLEsIllustrationNetworkElement extends Components.EsIllustrationNetwork, HTMLStencilElement {
     }
     var HTMLEsIllustrationNetworkElement: {
         prototype: HTMLEsIllustrationNetworkElement;
         new (): HTMLEsIllustrationNetworkElement;
     };
+    /**
+     * Displays Notifications illustration.
+     */
     interface HTMLEsIllustrationNotificationsElement extends Components.EsIllustrationNotifications, HTMLStencilElement {
     }
     var HTMLEsIllustrationNotificationsElement: {
         prototype: HTMLEsIllustrationNotificationsElement;
         new (): HTMLEsIllustrationNotificationsElement;
     };
+    /**
+     * Displays Peering illustration.
+     */
     interface HTMLEsIllustrationPeeringElement extends Components.EsIllustrationPeering, HTMLStencilElement {
     }
     var HTMLEsIllustrationPeeringElement: {
         prototype: HTMLEsIllustrationPeeringElement;
         new (): HTMLEsIllustrationPeeringElement;
     };
+    /**
+     * Displays Pending Member illustration.
+     */
     interface HTMLEsIllustrationPendingMemberElement extends Components.EsIllustrationPendingMember, HTMLStencilElement {
     }
     var HTMLEsIllustrationPendingMemberElement: {
         prototype: HTMLEsIllustrationPendingMemberElement;
         new (): HTMLEsIllustrationPendingMemberElement;
     };
+    /**
+     * Displays Policy illustration.
+     */
     interface HTMLEsIllustrationPolicyElement extends Components.EsIllustrationPolicy, HTMLStencilElement {
     }
     var HTMLEsIllustrationPolicyElement: {
         prototype: HTMLEsIllustrationPolicyElement;
         new (): HTMLEsIllustrationPolicyElement;
     };
+    /**
+     * Displays Poo illustration.
+     */
     interface HTMLEsIllustrationPooElement extends Components.EsIllustrationPoo, HTMLStencilElement {
     }
     var HTMLEsIllustrationPooElement: {
         prototype: HTMLEsIllustrationPooElement;
         new (): HTMLEsIllustrationPooElement;
     };
+    /**
+     * Displays Rain Cloud illustration.
+     */
     interface HTMLEsIllustrationRainCloudElement extends Components.EsIllustrationRainCloud, HTMLStencilElement {
     }
     var HTMLEsIllustrationRainCloudElement: {
         prototype: HTMLEsIllustrationRainCloudElement;
         new (): HTMLEsIllustrationRainCloudElement;
     };
+    /**
+     * Displays Role illustration.
+     */
     interface HTMLEsIllustrationRoleElement extends Components.EsIllustrationRole, HTMLStencilElement {
     }
     var HTMLEsIllustrationRoleElement: {
         prototype: HTMLEsIllustrationRoleElement;
         new (): HTMLEsIllustrationRoleElement;
     };
+    /**
+     * Displays Scheduled Backups illustration.
+     */
     interface HTMLEsIllustrationScheduledBackupsElement extends Components.EsIllustrationScheduledBackups, HTMLStencilElement {
     }
     var HTMLEsIllustrationScheduledBackupsElement: {
         prototype: HTMLEsIllustrationScheduledBackupsElement;
         new (): HTMLEsIllustrationScheduledBackupsElement;
     };
+    /**
+     * Displays Stream illustration.
+     */
     interface HTMLEsIllustrationStreamElement extends Components.EsIllustrationStream, HTMLStencilElement {
     }
     var HTMLEsIllustrationStreamElement: {
         prototype: HTMLEsIllustrationStreamElement;
         new (): HTMLEsIllustrationStreamElement;
     };
+    /**
+     * Displays Token illustration.
+     */
     interface HTMLEsIllustrationTokenElement extends Components.EsIllustrationToken, HTMLStencilElement {
     }
     var HTMLEsIllustrationTokenElement: {
         prototype: HTMLEsIllustrationTokenElement;
         new (): HTMLEsIllustrationTokenElement;
     };
+    /**
+     * Displays Welcome illustration.
+     */
     interface HTMLEsIllustrationWelcomeElement extends Components.EsIllustrationWelcome, HTMLStencilElement {
     }
     var HTMLEsIllustrationWelcomeElement: {
@@ -219,50 +357,119 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * Displays Backups illustration.
+     */
     interface EsIllustrationBackups {
     }
+    /**
+     * Displays Building Orgs illustration.
+     */
     interface EsIllustrationBuildingOrgs {
     }
+    /**
+     * Displays Cloud Folder illustration.
+     */
     interface EsIllustrationCloudFolder {
     }
+    /**
+     * Displays Cluster illustration.
+     */
     interface EsIllustrationCluster {
     }
+    /**
+     * Displays Es Database illustration.
+     */
     interface EsIllustrationEsDatabase {
     }
+    /**
+     * Displays Event illustration.
+     */
     interface EsIllustrationEvent {
     }
+    /**
+     * Displays Group illustration.
+     */
     interface EsIllustrationGroup {
     }
+    /**
+     * Displays Harddrive illustration.
+     */
     interface EsIllustrationHarddrive {
     }
+    /**
+     * Displays Integration illustration.
+     */
     interface EsIllustrationIntegration {
     }
+    /**
+     * Displays Issues illustration.
+     */
     interface EsIllustrationIssues {
     }
+    /**
+     * Displays Laptop illustration.
+     */
     interface EsIllustrationLaptop {
     }
+    /**
+     * Displays Network illustration.
+     */
     interface EsIllustrationNetwork {
     }
+    /**
+     * Displays Notifications illustration.
+     */
     interface EsIllustrationNotifications {
     }
+    /**
+     * Displays Peering illustration.
+     */
     interface EsIllustrationPeering {
     }
+    /**
+     * Displays Pending Member illustration.
+     */
     interface EsIllustrationPendingMember {
     }
+    /**
+     * Displays Policy illustration.
+     */
     interface EsIllustrationPolicy {
     }
+    /**
+     * Displays Poo illustration.
+     */
     interface EsIllustrationPoo {
     }
+    /**
+     * Displays Rain Cloud illustration.
+     */
     interface EsIllustrationRainCloud {
     }
+    /**
+     * Displays Role illustration.
+     */
     interface EsIllustrationRole {
     }
+    /**
+     * Displays Scheduled Backups illustration.
+     */
     interface EsIllustrationScheduledBackups {
     }
+    /**
+     * Displays Stream illustration.
+     */
     interface EsIllustrationStream {
     }
+    /**
+     * Displays Token illustration.
+     */
     interface EsIllustrationToken {
     }
+    /**
+     * Displays Welcome illustration.
+     */
     interface EsIllustrationWelcome {
     }
     interface IntrinsicElements {
@@ -295,28 +502,97 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * Displays Backups illustration.
+             */
             "es-illustration-backups": LocalJSX.EsIllustrationBackups & JSXBase.HTMLAttributes<HTMLEsIllustrationBackupsElement>;
+            /**
+             * Displays Building Orgs illustration.
+             */
             "es-illustration-building-orgs": LocalJSX.EsIllustrationBuildingOrgs & JSXBase.HTMLAttributes<HTMLEsIllustrationBuildingOrgsElement>;
+            /**
+             * Displays Cloud Folder illustration.
+             */
             "es-illustration-cloud-folder": LocalJSX.EsIllustrationCloudFolder & JSXBase.HTMLAttributes<HTMLEsIllustrationCloudFolderElement>;
+            /**
+             * Displays Cluster illustration.
+             */
             "es-illustration-cluster": LocalJSX.EsIllustrationCluster & JSXBase.HTMLAttributes<HTMLEsIllustrationClusterElement>;
+            /**
+             * Displays Es Database illustration.
+             */
             "es-illustration-es-database": LocalJSX.EsIllustrationEsDatabase & JSXBase.HTMLAttributes<HTMLEsIllustrationEsDatabaseElement>;
+            /**
+             * Displays Event illustration.
+             */
             "es-illustration-event": LocalJSX.EsIllustrationEvent & JSXBase.HTMLAttributes<HTMLEsIllustrationEventElement>;
+            /**
+             * Displays Group illustration.
+             */
             "es-illustration-group": LocalJSX.EsIllustrationGroup & JSXBase.HTMLAttributes<HTMLEsIllustrationGroupElement>;
+            /**
+             * Displays Harddrive illustration.
+             */
             "es-illustration-harddrive": LocalJSX.EsIllustrationHarddrive & JSXBase.HTMLAttributes<HTMLEsIllustrationHarddriveElement>;
+            /**
+             * Displays Integration illustration.
+             */
             "es-illustration-integration": LocalJSX.EsIllustrationIntegration & JSXBase.HTMLAttributes<HTMLEsIllustrationIntegrationElement>;
+            /**
+             * Displays Issues illustration.
+             */
             "es-illustration-issues": LocalJSX.EsIllustrationIssues & JSXBase.HTMLAttributes<HTMLEsIllustrationIssuesElement>;
+            /**
+             * Displays Laptop illustration.
+             */
             "es-illustration-laptop": LocalJSX.EsIllustrationLaptop & JSXBase.HTMLAttributes<HTMLEsIllustrationLaptopElement>;
+            /**
+             * Displays Network illustration.
+             */
             "es-illustration-network": LocalJSX.EsIllustrationNetwork & JSXBase.HTMLAttributes<HTMLEsIllustrationNetworkElement>;
+            /**
+             * Displays Notifications illustration.
+             */
             "es-illustration-notifications": LocalJSX.EsIllustrationNotifications & JSXBase.HTMLAttributes<HTMLEsIllustrationNotificationsElement>;
+            /**
+             * Displays Peering illustration.
+             */
             "es-illustration-peering": LocalJSX.EsIllustrationPeering & JSXBase.HTMLAttributes<HTMLEsIllustrationPeeringElement>;
+            /**
+             * Displays Pending Member illustration.
+             */
             "es-illustration-pending-member": LocalJSX.EsIllustrationPendingMember & JSXBase.HTMLAttributes<HTMLEsIllustrationPendingMemberElement>;
+            /**
+             * Displays Policy illustration.
+             */
             "es-illustration-policy": LocalJSX.EsIllustrationPolicy & JSXBase.HTMLAttributes<HTMLEsIllustrationPolicyElement>;
+            /**
+             * Displays Poo illustration.
+             */
             "es-illustration-poo": LocalJSX.EsIllustrationPoo & JSXBase.HTMLAttributes<HTMLEsIllustrationPooElement>;
+            /**
+             * Displays Rain Cloud illustration.
+             */
             "es-illustration-rain-cloud": LocalJSX.EsIllustrationRainCloud & JSXBase.HTMLAttributes<HTMLEsIllustrationRainCloudElement>;
+            /**
+             * Displays Role illustration.
+             */
             "es-illustration-role": LocalJSX.EsIllustrationRole & JSXBase.HTMLAttributes<HTMLEsIllustrationRoleElement>;
+            /**
+             * Displays Scheduled Backups illustration.
+             */
             "es-illustration-scheduled-backups": LocalJSX.EsIllustrationScheduledBackups & JSXBase.HTMLAttributes<HTMLEsIllustrationScheduledBackupsElement>;
+            /**
+             * Displays Stream illustration.
+             */
             "es-illustration-stream": LocalJSX.EsIllustrationStream & JSXBase.HTMLAttributes<HTMLEsIllustrationStreamElement>;
+            /**
+             * Displays Token illustration.
+             */
             "es-illustration-token": LocalJSX.EsIllustrationToken & JSXBase.HTMLAttributes<HTMLEsIllustrationTokenElement>;
+            /**
+             * Displays Welcome illustration.
+             */
             "es-illustration-welcome": LocalJSX.EsIllustrationWelcome & JSXBase.HTMLAttributes<HTMLEsIllustrationWelcomeElement>;
         }
     }

--- a/packages/illustrations/src/components/backups/readme.md
+++ b/packages/illustrations/src/components/backups/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Backups illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/building-orgs/readme.md
+++ b/packages/illustrations/src/components/building-orgs/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Building Orgs illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/cloud-folder/readme.md
+++ b/packages/illustrations/src/components/cloud-folder/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Cloud Folder illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/cluster/readme.md
+++ b/packages/illustrations/src/components/cluster/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Cluster illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/es-database/readme.md
+++ b/packages/illustrations/src/components/es-database/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Es Database illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/event/readme.md
+++ b/packages/illustrations/src/components/event/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Event illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/group/readme.md
+++ b/packages/illustrations/src/components/group/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Group illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/harddrive/readme.md
+++ b/packages/illustrations/src/components/harddrive/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Harddrive illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/integration/readme.md
+++ b/packages/illustrations/src/components/integration/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Integration illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/issues/readme.md
+++ b/packages/illustrations/src/components/issues/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Issues illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/laptop/readme.md
+++ b/packages/illustrations/src/components/laptop/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Laptop illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/network/readme.md
+++ b/packages/illustrations/src/components/network/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Network illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/notifications/readme.md
+++ b/packages/illustrations/src/components/notifications/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Notifications illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/peering/readme.md
+++ b/packages/illustrations/src/components/peering/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Peering illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/pending-member/readme.md
+++ b/packages/illustrations/src/components/pending-member/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Pending Member illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/policy/readme.md
+++ b/packages/illustrations/src/components/policy/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Policy illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/poo/readme.md
+++ b/packages/illustrations/src/components/poo/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Poo illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/rain-cloud/readme.md
+++ b/packages/illustrations/src/components/rain-cloud/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Rain Cloud illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/role/readme.md
+++ b/packages/illustrations/src/components/role/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Role illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/scheduled-backups/readme.md
+++ b/packages/illustrations/src/components/scheduled-backups/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Scheduled Backups illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/stream/readme.md
+++ b/packages/illustrations/src/components/stream/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Stream illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/token/readme.md
+++ b/packages/illustrations/src/components/token/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Token illustration.
+
 ## Usage
 
 ### Example

--- a/packages/illustrations/src/components/welcome/readme.md
+++ b/packages/illustrations/src/components/welcome/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays Welcome illustration.
+
 ## Usage
 
 ### Example

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -62,11 +62,11 @@
         "@eventstore-ui/router": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
-        "puppeteer": "10.4.0",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "puppeteer": "^19.5.0",
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -62,7 +62,7 @@
         "@eventstore-ui/router": "workspace:*",
         "@eventstore-ui/theme": "workspace:*",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "puppeteer": "^19.5.0",

--- a/packages/layout/src/components.d.ts
+++ b/packages/layout/src/components.d.ts
@@ -11,7 +11,16 @@ import { HeaderDropdownButtonVariant } from "./components/es-header-dropdown/typ
 import { IconDescription } from "@eventstore-ui/components";
 import { LoadingBarStatus } from "./components/es-loading-bar/types";
 import { NavNode, NavTree } from "./components/es-nav/types";
+export { Crumb } from "./components/es-breadcrumb/types";
+export { DisplayErrorVariant } from "./components/es-display-error/types";
+export { HeaderDropdownButtonVariant } from "./components/es-header-dropdown/types";
+export { IconDescription } from "@eventstore-ui/components";
+export { LoadingBarStatus } from "./components/es-loading-bar/types";
+export { NavNode, NavTree } from "./components/es-nav/types";
 export namespace Components {
+    /**
+     * A list of breadcrumbs to the current page
+     */
     interface EsBreadcrumb {
         /**
           * The breadcrumbs to the current page.
@@ -22,6 +31,9 @@ export namespace Components {
          */
         "noValidate": boolean;
     }
+    /**
+     * Display an error to the user, with title and detail. Will automatically extract from HTTPError.
+     */
     interface EsDisplayError {
         /**
           * The unrecoverable error. For a normal error, error.message will be displayed. For a `HTTPError` from `@eventstore-ui/utils` the details title and description will be shown.
@@ -32,8 +44,14 @@ export namespace Components {
          */
         "variant": DisplayErrorVariant;
     }
+    /**
+     * A site header for applications.
+     */
     interface EsHeader {
     }
+    /**
+     * A dropdown for the header.
+     */
     interface EsHeaderDropdown {
         /**
           * Display a dot on the icon, to attract attention to the button.
@@ -68,6 +86,9 @@ export namespace Components {
          */
         "variant": HeaderDropdownButtonVariant;
     }
+    /**
+     * A button for the sidebar, sidebar-dropdown, and header-dropdown.
+     */
     interface EsLayoutButton {
         /**
           * If the button should display as active
@@ -106,6 +127,9 @@ export namespace Components {
          */
         "priority": number;
     }
+    /**
+     * A link for the sidebar, sidebar-dropdown, and header-dropdown.
+     */
     interface EsLayoutLink {
         /**
           * Display a dot on the icon, to attract attention to the link.
@@ -164,6 +188,9 @@ export namespace Components {
          */
         "url"?: string;
     }
+    /**
+     * A section with an optional title for containing layout-links
+     */
     interface EsLayoutSection {
         /**
           * If the section is collapsable
@@ -178,6 +205,11 @@ export namespace Components {
          */
         "sectionTitle"?: string;
     }
+    /**
+     * An animated loading bar, with coloured states.
+     * The bar can be externally controlled via the `setProgress` util.
+     * Add a bar named `page` for automatic control from `Page`.
+     */
     interface EsLoadingBar {
         /**
           * The bar's name, for use in `setProgress`
@@ -188,6 +220,9 @@ export namespace Components {
          */
         "progress": (completion: number, status?: LoadingBarStatus) => Promise<void>;
     }
+    /**
+     * The Event Store logo.
+     */
     interface EsLogo {
         /**
           * Height to constrain by.
@@ -198,6 +233,9 @@ export namespace Components {
          */
         "width": number;
     }
+    /**
+     * Constructs a navigation from a NavTree.
+     */
     interface EsNav {
         /**
           * The `NavTree` data structure that the navigation menu will be built from..
@@ -217,14 +255,29 @@ export namespace Components {
     interface EsNavNode2 {
         "node": NavNode;
     }
+    /**
+     * Standard page title
+     */
     interface EsPageTitle {
     }
+    /**
+     * A panel. Automatically sets `--layout-panel-height` based on it's height, and when resized.
+     */
     interface EsPanel {
     }
+    /**
+     * A header for `es-panel`.
+     */
     interface EsPanelHeader {
     }
+    /**
+     * A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.
+     */
     interface EsSidebar {
     }
+    /**
+     * A dropdown for the sidebar. Will automatically take the title and icon of the first active nested `es-layout-link` or `es-layout-button`.
+     */
     interface EsSidebarDropdown {
         /**
           * The icon to display if no nested es-layout-link or es-layout-button is active
@@ -235,6 +288,9 @@ export namespace Components {
          */
         "defaultTitle": string;
     }
+    /**
+     * A theme picker dropdown for the header
+     */
     interface EsThemeDropdown {
         /**
           * Which styling variant to use.
@@ -243,6 +299,9 @@ export namespace Components {
     }
     interface EsThemePicker {
     }
+    /**
+     * Placed in the toolbar area of the layout. Automatically sets `--layout-toolbar-width` based on it's own width.
+     */
     interface EsToolbar {
     }
 }
@@ -251,60 +310,92 @@ export interface EsLayoutButtonCustomEvent<T> extends CustomEvent<T> {
     target: HTMLEsLayoutButtonElement;
 }
 declare global {
+    /**
+     * A list of breadcrumbs to the current page
+     */
     interface HTMLEsBreadcrumbElement extends Components.EsBreadcrumb, HTMLStencilElement {
     }
     var HTMLEsBreadcrumbElement: {
         prototype: HTMLEsBreadcrumbElement;
         new (): HTMLEsBreadcrumbElement;
     };
+    /**
+     * Display an error to the user, with title and detail. Will automatically extract from HTTPError.
+     */
     interface HTMLEsDisplayErrorElement extends Components.EsDisplayError, HTMLStencilElement {
     }
     var HTMLEsDisplayErrorElement: {
         prototype: HTMLEsDisplayErrorElement;
         new (): HTMLEsDisplayErrorElement;
     };
+    /**
+     * A site header for applications.
+     */
     interface HTMLEsHeaderElement extends Components.EsHeader, HTMLStencilElement {
     }
     var HTMLEsHeaderElement: {
         prototype: HTMLEsHeaderElement;
         new (): HTMLEsHeaderElement;
     };
+    /**
+     * A dropdown for the header.
+     */
     interface HTMLEsHeaderDropdownElement extends Components.EsHeaderDropdown, HTMLStencilElement {
     }
     var HTMLEsHeaderDropdownElement: {
         prototype: HTMLEsHeaderDropdownElement;
         new (): HTMLEsHeaderDropdownElement;
     };
+    /**
+     * A button for the sidebar, sidebar-dropdown, and header-dropdown.
+     */
     interface HTMLEsLayoutButtonElement extends Components.EsLayoutButton, HTMLStencilElement {
     }
     var HTMLEsLayoutButtonElement: {
         prototype: HTMLEsLayoutButtonElement;
         new (): HTMLEsLayoutButtonElement;
     };
+    /**
+     * A link for the sidebar, sidebar-dropdown, and header-dropdown.
+     */
     interface HTMLEsLayoutLinkElement extends Components.EsLayoutLink, HTMLStencilElement {
     }
     var HTMLEsLayoutLinkElement: {
         prototype: HTMLEsLayoutLinkElement;
         new (): HTMLEsLayoutLinkElement;
     };
+    /**
+     * A section with an optional title for containing layout-links
+     */
     interface HTMLEsLayoutSectionElement extends Components.EsLayoutSection, HTMLStencilElement {
     }
     var HTMLEsLayoutSectionElement: {
         prototype: HTMLEsLayoutSectionElement;
         new (): HTMLEsLayoutSectionElement;
     };
+    /**
+     * An animated loading bar, with coloured states.
+     * The bar can be externally controlled via the `setProgress` util.
+     * Add a bar named `page` for automatic control from `Page`.
+     */
     interface HTMLEsLoadingBarElement extends Components.EsLoadingBar, HTMLStencilElement {
     }
     var HTMLEsLoadingBarElement: {
         prototype: HTMLEsLoadingBarElement;
         new (): HTMLEsLoadingBarElement;
     };
+    /**
+     * The Event Store logo.
+     */
     interface HTMLEsLogoElement extends Components.EsLogo, HTMLStencilElement {
     }
     var HTMLEsLogoElement: {
         prototype: HTMLEsLogoElement;
         new (): HTMLEsLogoElement;
     };
+    /**
+     * Constructs a navigation from a NavTree.
+     */
     interface HTMLEsNavElement extends Components.EsNav, HTMLStencilElement {
     }
     var HTMLEsNavElement: {
@@ -329,36 +420,54 @@ declare global {
         prototype: HTMLEsNavNode2Element;
         new (): HTMLEsNavNode2Element;
     };
+    /**
+     * Standard page title
+     */
     interface HTMLEsPageTitleElement extends Components.EsPageTitle, HTMLStencilElement {
     }
     var HTMLEsPageTitleElement: {
         prototype: HTMLEsPageTitleElement;
         new (): HTMLEsPageTitleElement;
     };
+    /**
+     * A panel. Automatically sets `--layout-panel-height` based on it's height, and when resized.
+     */
     interface HTMLEsPanelElement extends Components.EsPanel, HTMLStencilElement {
     }
     var HTMLEsPanelElement: {
         prototype: HTMLEsPanelElement;
         new (): HTMLEsPanelElement;
     };
+    /**
+     * A header for `es-panel`.
+     */
     interface HTMLEsPanelHeaderElement extends Components.EsPanelHeader, HTMLStencilElement {
     }
     var HTMLEsPanelHeaderElement: {
         prototype: HTMLEsPanelHeaderElement;
         new (): HTMLEsPanelHeaderElement;
     };
+    /**
+     * A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.
+     */
     interface HTMLEsSidebarElement extends Components.EsSidebar, HTMLStencilElement {
     }
     var HTMLEsSidebarElement: {
         prototype: HTMLEsSidebarElement;
         new (): HTMLEsSidebarElement;
     };
+    /**
+     * A dropdown for the sidebar. Will automatically take the title and icon of the first active nested `es-layout-link` or `es-layout-button`.
+     */
     interface HTMLEsSidebarDropdownElement extends Components.EsSidebarDropdown, HTMLStencilElement {
     }
     var HTMLEsSidebarDropdownElement: {
         prototype: HTMLEsSidebarDropdownElement;
         new (): HTMLEsSidebarDropdownElement;
     };
+    /**
+     * A theme picker dropdown for the header
+     */
     interface HTMLEsThemeDropdownElement extends Components.EsThemeDropdown, HTMLStencilElement {
     }
     var HTMLEsThemeDropdownElement: {
@@ -371,6 +480,9 @@ declare global {
         prototype: HTMLEsThemePickerElement;
         new (): HTMLEsThemePickerElement;
     };
+    /**
+     * Placed in the toolbar area of the layout. Automatically sets `--layout-toolbar-width` based on it's own width.
+     */
     interface HTMLEsToolbarElement extends Components.EsToolbar, HTMLStencilElement {
     }
     var HTMLEsToolbarElement: {
@@ -402,6 +514,9 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    /**
+     * A list of breadcrumbs to the current page
+     */
     interface EsBreadcrumb {
         /**
           * The breadcrumbs to the current page.
@@ -412,6 +527,9 @@ declare namespace LocalJSX {
          */
         "noValidate"?: boolean;
     }
+    /**
+     * Display an error to the user, with title and detail. Will automatically extract from HTTPError.
+     */
     interface EsDisplayError {
         /**
           * The unrecoverable error. For a normal error, error.message will be displayed. For a `HTTPError` from `@eventstore-ui/utils` the details title and description will be shown.
@@ -422,8 +540,14 @@ declare namespace LocalJSX {
          */
         "variant"?: DisplayErrorVariant;
     }
+    /**
+     * A site header for applications.
+     */
     interface EsHeader {
     }
+    /**
+     * A dropdown for the header.
+     */
     interface EsHeaderDropdown {
         /**
           * Display a dot on the icon, to attract attention to the button.
@@ -458,6 +582,9 @@ declare namespace LocalJSX {
          */
         "variant"?: HeaderDropdownButtonVariant;
     }
+    /**
+     * A button for the sidebar, sidebar-dropdown, and header-dropdown.
+     */
     interface EsLayoutButton {
         /**
           * If the button should display as active
@@ -496,6 +623,9 @@ declare namespace LocalJSX {
          */
         "priority"?: number;
     }
+    /**
+     * A link for the sidebar, sidebar-dropdown, and header-dropdown.
+     */
     interface EsLayoutLink {
         /**
           * Display a dot on the icon, to attract attention to the link.
@@ -550,6 +680,9 @@ declare namespace LocalJSX {
          */
         "url"?: string;
     }
+    /**
+     * A section with an optional title for containing layout-links
+     */
     interface EsLayoutSection {
         /**
           * If the section is collapsable
@@ -564,12 +697,20 @@ declare namespace LocalJSX {
          */
         "sectionTitle"?: string;
     }
+    /**
+     * An animated loading bar, with coloured states.
+     * The bar can be externally controlled via the `setProgress` util.
+     * Add a bar named `page` for automatic control from `Page`.
+     */
     interface EsLoadingBar {
         /**
           * The bar's name, for use in `setProgress`
          */
         "name": string;
     }
+    /**
+     * The Event Store logo.
+     */
     interface EsLogo {
         /**
           * Height to constrain by.
@@ -580,6 +721,9 @@ declare namespace LocalJSX {
          */
         "width"?: number;
     }
+    /**
+     * Constructs a navigation from a NavTree.
+     */
     interface EsNav {
         /**
           * The `NavTree` data structure that the navigation menu will be built from..
@@ -599,14 +743,29 @@ declare namespace LocalJSX {
     interface EsNavNode2 {
         "node": NavNode;
     }
+    /**
+     * Standard page title
+     */
     interface EsPageTitle {
     }
+    /**
+     * A panel. Automatically sets `--layout-panel-height` based on it's height, and when resized.
+     */
     interface EsPanel {
     }
+    /**
+     * A header for `es-panel`.
+     */
     interface EsPanelHeader {
     }
+    /**
+     * A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.
+     */
     interface EsSidebar {
     }
+    /**
+     * A dropdown for the sidebar. Will automatically take the title and icon of the first active nested `es-layout-link` or `es-layout-button`.
+     */
     interface EsSidebarDropdown {
         /**
           * The icon to display if no nested es-layout-link or es-layout-button is active
@@ -617,6 +776,9 @@ declare namespace LocalJSX {
          */
         "defaultTitle": string;
     }
+    /**
+     * A theme picker dropdown for the header
+     */
     interface EsThemeDropdown {
         /**
           * Which styling variant to use.
@@ -625,6 +787,9 @@ declare namespace LocalJSX {
     }
     interface EsThemePicker {
     }
+    /**
+     * Placed in the toolbar area of the layout. Automatically sets `--layout-toolbar-width` based on it's own width.
+     */
     interface EsToolbar {
     }
     interface IntrinsicElements {
@@ -655,26 +820,79 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            /**
+             * A list of breadcrumbs to the current page
+             */
             "es-breadcrumb": LocalJSX.EsBreadcrumb & JSXBase.HTMLAttributes<HTMLEsBreadcrumbElement>;
+            /**
+             * Display an error to the user, with title and detail. Will automatically extract from HTTPError.
+             */
             "es-display-error": LocalJSX.EsDisplayError & JSXBase.HTMLAttributes<HTMLEsDisplayErrorElement>;
+            /**
+             * A site header for applications.
+             */
             "es-header": LocalJSX.EsHeader & JSXBase.HTMLAttributes<HTMLEsHeaderElement>;
+            /**
+             * A dropdown for the header.
+             */
             "es-header-dropdown": LocalJSX.EsHeaderDropdown & JSXBase.HTMLAttributes<HTMLEsHeaderDropdownElement>;
+            /**
+             * A button for the sidebar, sidebar-dropdown, and header-dropdown.
+             */
             "es-layout-button": LocalJSX.EsLayoutButton & JSXBase.HTMLAttributes<HTMLEsLayoutButtonElement>;
+            /**
+             * A link for the sidebar, sidebar-dropdown, and header-dropdown.
+             */
             "es-layout-link": LocalJSX.EsLayoutLink & JSXBase.HTMLAttributes<HTMLEsLayoutLinkElement>;
+            /**
+             * A section with an optional title for containing layout-links
+             */
             "es-layout-section": LocalJSX.EsLayoutSection & JSXBase.HTMLAttributes<HTMLEsLayoutSectionElement>;
+            /**
+             * An animated loading bar, with coloured states.
+             * The bar can be externally controlled via the `setProgress` util.
+             * Add a bar named `page` for automatic control from `Page`.
+             */
             "es-loading-bar": LocalJSX.EsLoadingBar & JSXBase.HTMLAttributes<HTMLEsLoadingBarElement>;
+            /**
+             * The Event Store logo.
+             */
             "es-logo": LocalJSX.EsLogo & JSXBase.HTMLAttributes<HTMLEsLogoElement>;
+            /**
+             * Constructs a navigation from a NavTree.
+             */
             "es-nav": LocalJSX.EsNav & JSXBase.HTMLAttributes<HTMLEsNavElement>;
             "es-nav-node-0": LocalJSX.EsNavNode0 & JSXBase.HTMLAttributes<HTMLEsNavNode0Element>;
             "es-nav-node-1": LocalJSX.EsNavNode1 & JSXBase.HTMLAttributes<HTMLEsNavNode1Element>;
             "es-nav-node-2": LocalJSX.EsNavNode2 & JSXBase.HTMLAttributes<HTMLEsNavNode2Element>;
+            /**
+             * Standard page title
+             */
             "es-page-title": LocalJSX.EsPageTitle & JSXBase.HTMLAttributes<HTMLEsPageTitleElement>;
+            /**
+             * A panel. Automatically sets `--layout-panel-height` based on it's height, and when resized.
+             */
             "es-panel": LocalJSX.EsPanel & JSXBase.HTMLAttributes<HTMLEsPanelElement>;
+            /**
+             * A header for `es-panel`.
+             */
             "es-panel-header": LocalJSX.EsPanelHeader & JSXBase.HTMLAttributes<HTMLEsPanelHeaderElement>;
+            /**
+             * A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.
+             */
             "es-sidebar": LocalJSX.EsSidebar & JSXBase.HTMLAttributes<HTMLEsSidebarElement>;
+            /**
+             * A dropdown for the sidebar. Will automatically take the title and icon of the first active nested `es-layout-link` or `es-layout-button`.
+             */
             "es-sidebar-dropdown": LocalJSX.EsSidebarDropdown & JSXBase.HTMLAttributes<HTMLEsSidebarDropdownElement>;
+            /**
+             * A theme picker dropdown for the header
+             */
             "es-theme-dropdown": LocalJSX.EsThemeDropdown & JSXBase.HTMLAttributes<HTMLEsThemeDropdownElement>;
             "es-theme-picker": LocalJSX.EsThemePicker & JSXBase.HTMLAttributes<HTMLEsThemePickerElement>;
+            /**
+             * Placed in the toolbar area of the layout. Automatically sets `--layout-toolbar-width` based on it's own width.
+             */
             "es-toolbar": LocalJSX.EsToolbar & JSXBase.HTMLAttributes<HTMLEsToolbarElement>;
         }
     }

--- a/packages/layout/src/components/es-breadcrumb/readme.md
+++ b/packages/layout/src/components/es-breadcrumb/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A list of breadcrumbs to the current page
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-display-error/readme.md
+++ b/packages/layout/src/components/es-display-error/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Display an error to the user, with title and detail. Will automatically extract from HTTPError.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-header-dropdown/readme.md
+++ b/packages/layout/src/components/es-header-dropdown/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A dropdown for the header.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-header/readme.md
+++ b/packages/layout/src/components/es-header/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A site header for applications.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-layout-button/readme.md
+++ b/packages/layout/src/components/es-layout-button/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A button for the sidebar, sidebar-dropdown, and header-dropdown.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-layout-link/readme.md
+++ b/packages/layout/src/components/es-layout-link/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A link for the sidebar, sidebar-dropdown, and header-dropdown.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-layout-section/readme.md
+++ b/packages/layout/src/components/es-layout-section/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A section with an optional title for containing layout-links
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-loading-bar/readme.md
+++ b/packages/layout/src/components/es-loading-bar/readme.md
@@ -5,6 +5,12 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+An animated loading bar, with coloured states.
+The bar can be externally controlled via the `setProgress` util.
+Add a bar named `page` for automatic control from `Page`.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-logo/readme.md
+++ b/packages/layout/src/components/es-logo/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+The Event Store logo.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-nav/readme.md
+++ b/packages/layout/src/components/es-nav/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Constructs a navigation from a NavTree.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-page-title/readme.md
+++ b/packages/layout/src/components/es-page-title/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Standard page title
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-panel-header/readme.md
+++ b/packages/layout/src/components/es-panel-header/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A header for `es-panel`.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-panel/readme.md
+++ b/packages/layout/src/components/es-panel/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A panel. Automatically sets `--layout-panel-height` based on it's height, and when resized.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-sidebar-dropdown/readme.md
+++ b/packages/layout/src/components/es-sidebar-dropdown/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A dropdown for the sidebar. Will automatically take the title and icon of the first active nested `es-layout-link` or `es-layout-button`.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-sidebar/readme.md
+++ b/packages/layout/src/components/es-sidebar/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-theme-dropdown/readme.md
+++ b/packages/layout/src/components/es-theme-dropdown/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+A theme picker dropdown for the header
+
 ## Usage
 
 ### Example

--- a/packages/layout/src/components/es-toolbar/readme.md
+++ b/packages/layout/src/components/es-toolbar/readme.md
@@ -3,6 +3,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Placed in the toolbar area of the layout. Automatically sets `--layout-toolbar-width` based on it's own width.
+
 ## Usage
 
 ### Example

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,10 +31,10 @@
     },
     "devDependencies": {
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "@types/jest": "^27.0.3",
         "jest": "^27.4.5",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,7 +33,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "@types/jest": "^27.0.3",
         "babel-jest": "^27.5.1",
         "jest": "^27.4.5",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -15,8 +15,7 @@
     "scripts": {
         "build": "tsc --outDir ./dist --declaration",
         "docs": "typedoc --logLevel Error --json ../../documentation/generated/router.typedoc.json",
-        "test": "stencil test --spec --passWithNoTests",
-        "test.watch": "stencil test --spec --watchAll",
+        "test": "jest --testEnvironment jsdom --passWithNoTests",
         "lint": "yarn g:lint"
     },
     "targets": {
@@ -30,11 +29,29 @@
         "@eventstore-ui/utils": "0.1.x"
     },
     "devDependencies": {
+        "@babel/core": "^7.12.10",
+        "@babel/preset-env": "^7.12.11",
+        "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/utils": "workspace:*",
         "@stencil/core": "3.0.0",
         "@types/jest": "^27.0.3",
+        "babel-jest": "^27.5.1",
         "jest": "^27.4.5",
+        "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
+    },
+    "babel": {
+        "presets": [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "current"
+                    }
+                }
+            ],
+            "@babel/preset-typescript"
+        ]
     }
 }

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -21,8 +21,7 @@
         "build:rollup": "rollup -c rollup.config.js",
         "build:cleanup": "rm -rf ./build",
         "docs": "typedoc --logLevel Error --json ../../documentation/generated/stores.typedoc.json",
-        "test": "stencil test --spec --passWithNoTests",
-        "test.watch": "stencil test --spec --watchAll",
+        "test": "jest --testEnvironment jsdom --passWithNoTests",
         "lint": "yarn g:lint"
     },
     "targets": {
@@ -36,13 +35,30 @@
         "@eventstore-ui/utils": "0.1.x"
     },
     "devDependencies": {
+        "@babel/core": "^7.12.10",
+        "@babel/preset-env": "^7.12.11",
+        "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/utils": "workspace:*",
         "@stencil/core": "3.0.0",
         "@types/jest": "^27.0.3",
+        "babel-jest": "^27.5.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
+    },
+    "babel": {
+        "presets": [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "current"
+                    }
+                }
+            ],
+            "@babel/preset-typescript"
+        ]
     }
 }

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -39,7 +39,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "@types/jest": "^27.0.3",
         "babel-jest": "^27.5.1",
         "jest": "^27.4.5",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -37,12 +37,12 @@
     },
     "devDependencies": {
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "@types/jest": "^27.0.3",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.52.7",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -33,7 +33,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "babel-jest": "^27.5.1",
         "jest": "^27.4.5",
         "rollup": "^2.52.7",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,8 +15,7 @@
     "scripts": {
         "build": "tsc --outDir ./dist --declaration",
         "docs": "typedoc --logLevel Error --json ../../documentation/generated/theme.typedoc.json",
-        "test": "stencil test --spec --passWithNoTests",
-        "test.watch": "stencil test --spec --watchAll",
+        "test": "jest --testEnvironment jsdom --passWithNoTests",
         "lint": "yarn g:lint"
     },
     "targets": {
@@ -30,10 +29,28 @@
         "@eventstore-ui/utils": "0.1.x"
     },
     "devDependencies": {
+        "@babel/core": "^7.12.10",
+        "@babel/preset-env": "^7.12.11",
+        "@babel/preset-typescript": "^7.12.7",
         "@eventstore-ui/utils": "workspace:*",
         "@stencil/core": "3.0.0",
+        "babel-jest": "^27.5.1",
         "jest": "^27.4.5",
+        "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
+    },
+    "babel": {
+        "presets": [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "current"
+                    }
+                }
+            ],
+            "@babel/preset-typescript"
+        ]
     }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -31,9 +31,9 @@
     },
     "devDependencies": {
         "@eventstore-ui/utils": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "jest": "^27.4.5",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,7 +39,7 @@
         "babel-jest": "^27.5.1",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
-        "rollup": "2.33.1",
+        "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,8 +40,8 @@
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "rollup": "2.33.1",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     },
     "babel": {
         "presets": [

--- a/tools/configs/package.json
+++ b/tools/configs/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@eventstore-ui/assets": "workspace:*",
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "@stencil/postcss": "^2.1.0",
         "postcss-preset-env": "6.7.0"
     },

--- a/tools/configs/package.json
+++ b/tools/configs/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@eventstore-ui/assets": "workspace:*",
-        "@stencil/core": "2.17.4",
+        "@stencil/core": "3.0.0",
         "@stencil/postcss": "^2.1.0",
         "postcss-preset-env": "6.7.0"
     },
@@ -39,6 +39,6 @@
         "@typescript-eslint/parser": "^5.6.0",
         "eslint": "^8.4.0",
         "prettier": "^2.2.1",
-        "typescript": "4.5.5"
+        "typescript": "4.9.4"
     }
 }

--- a/tools/icon-manager/package.json
+++ b/tools/icon-manager/package.json
@@ -30,10 +30,10 @@
         "yargs": "^15.3.1"
     },
     "devDependencies": {
-        "@types/node": "^16.11.9",
+        "@types/node": "^18.11.18",
         "@types/semver": "^7.3.9",
         "@types/svgo": "^2.6.3",
         "jest": "^27.4.5",
-        "typescript": "4.5.5"
+        "typescript": "4.9.4"
     }
 }

--- a/tools/stencil-markdown-plugin/package.json
+++ b/tools/stencil-markdown-plugin/package.json
@@ -48,12 +48,12 @@
         "unist-util-visit": "^2.0.3"
     },
     "devDependencies": {
-        "@stencil/core": "2.17.4",
-        "@types/node": "^16.11.9",
+        "@stencil/core": "3.0.0",
+        "@types/node": "^18.11.18",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.18.2",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/tools/stencil-markdown-plugin/package.json
+++ b/tools/stencil-markdown-plugin/package.json
@@ -48,7 +48,7 @@
         "unist-util-visit": "^2.0.3"
     },
     "devDependencies": {
-        "@stencil/core": "3.0.0",
+        "@stencil/core": "3.0.1",
         "@types/node": "^18.11.18",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",

--- a/tools/stencil-markdown-plugin/package.json
+++ b/tools/stencil-markdown-plugin/package.json
@@ -52,7 +52,7 @@
         "@types/node": "^18.11.18",
         "jest": "^27.4.5",
         "npm-run-all": "^4.1.5",
-        "rollup": "^2.18.2",
+        "rollup": "^2.52.7",
         "typedoc": "0.23.24",
         "typescript": "4.9.4"
     }

--- a/tools/typedoc-plugin-usage/package.json
+++ b/tools/typedoc-plugin-usage/package.json
@@ -26,8 +26,8 @@
         "typedoc": ">=0.21.0"
     },
     "devDependencies": {
-        "@types/node": "^16.11.9",
-        "typedoc": "^0.22.13",
-        "typescript": "4.5.5"
+        "@types/node": "^18.11.18",
+        "typedoc": "0.23.24",
+        "typescript": "4.9.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,7 +3014,7 @@ __metadata:
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
     "@floating-ui/dom": 0.4.1
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     puppeteer: ^19.5.0
@@ -3032,7 +3032,7 @@ __metadata:
   resolution: "@eventstore-ui/configs@workspace:tools/configs"
   dependencies:
     "@eventstore-ui/assets": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     "@stencil/postcss": ^2.1.0
     "@typescript-eslint/eslint-plugin": ^5.6.0
     "@typescript-eslint/parser": ^5.6.0
@@ -3065,7 +3065,7 @@ __metadata:
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     "@stencil/postcss": ^2.1.0
     "@types/jest": ^27.0.3
     "@types/markdown-it": 12.0.3
@@ -3096,7 +3096,7 @@ __metadata:
     "@eventstore-ui/configs": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     jest: ^27.4.5
     monaco-editor: ^0.22.3
     npm-run-all: ^4.1.5
@@ -3120,7 +3120,7 @@ __metadata:
     "@eventstore-ui/icon-manager": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     imask: 6.0.5
     jest: ^27.4.5
     npm-run-all: ^4.1.5
@@ -3144,7 +3144,7 @@ __metadata:
     "@eventstore-ui/components": "workspace:*"
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     "@types/jest": ^27.0.3
     babel-jest: ^27.5.1
     jest: ^27.4.5
@@ -3184,7 +3184,7 @@ __metadata:
   resolution: "@eventstore-ui/illustrations@workspace:packages/illustrations"
   dependencies:
     "@eventstore-ui/theme": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     case-anything: ^2.1.10
     jest: ^27.4.5
     npm-run-all: ^4.1.5
@@ -3210,7 +3210,7 @@ __metadata:
     "@eventstore-ui/router": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     puppeteer: ^19.5.0
@@ -3233,7 +3233,7 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     "@types/jest": ^27.0.3
     babel-jest: ^27.5.1
     jest: ^27.4.5
@@ -3251,7 +3251,7 @@ __metadata:
   dependencies:
     "@mdx-js/mdx": ^1.6.22
     "@rollup/pluginutils": ^3.1.0
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     "@types/node": ^18.11.18
     jest: ^27.4.5
     npm-run-all: ^4.1.5
@@ -3272,7 +3272,7 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     "@types/jest": ^27.0.3
     babel-jest: ^27.5.1
     jest: ^27.4.5
@@ -3293,7 +3293,7 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
     babel-jest: ^27.5.1
     jest: ^27.4.5
     rollup: ^2.52.7
@@ -3845,12 +3845,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/core@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@stencil/core@npm:3.0.0"
+"@stencil/core@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@stencil/core@npm:3.0.1"
   bin:
     stencil: bin/stencil
-  checksum: 1396d1e68686d9cb646b07e844523602d09a29d837627fd3a46fbaf806331872181a61a47bba3efd68f9486e140c1bf72d20a73ab5922f1c4dc4a37d99c308b2
+  checksum: fe4f03106316b648c406be842eb6181b27c7e76892bd72a313792557538942be8c20d1af346060fbaf94c3b1e53956d2cc5cd891136261ba5abb512196646158
   languageName: node
   linkType: hard
 
@@ -6540,7 +6540,7 @@ __metadata:
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
   languageName: unknown
   linkType: soft
 
@@ -10544,7 +10544,7 @@ __metadata:
   resolution: "router-demo@workspace:demos/router-demo"
   dependencies:
     "@eventstore-ui/router": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
   languageName: unknown
   linkType: soft
 
@@ -10963,7 +10963,7 @@ __metadata:
   dependencies:
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 3.0.0
+    "@stencil/core": 3.0.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,6 +3057,7 @@ __metadata:
     "@eventstore-ui/configs": "workspace:*"
     "@eventstore-ui/editor": "workspace:*"
     "@eventstore-ui/fields": "workspace:*"
+    "@eventstore-ui/forms": "workspace:*"
     "@eventstore-ui/icon-manager": "workspace:*"
     "@eventstore-ui/illustrations": "workspace:*"
     "@eventstore-ui/layout": "workspace:*"
@@ -3078,9 +3079,7 @@ __metadata:
     postcss-preset-env: 6.7.0
     prettier: 2.2.1
     puppeteer: ^19.5.0
-    rollup: 2.33.1
-    rollup-plugin-node-polyfills: 0.2.1
-    rollup-plugin-require-context: 0.0.2
+    rollup: ^2.52.7
     rollup-plugin-string: 3.0.0
     serve: 14.0.1
     typedoc: 0.23.24
@@ -3102,7 +3101,7 @@ __metadata:
     monaco-editor: ^0.22.3
     npm-run-all: ^4.1.5
     puppeteer: ^19.5.0
-    rollup: 2.33.1
+    rollup: ^2.52.7
     typedoc: 0.23.24
     typescript: 4.9.4
   peerDependencies:
@@ -3247,7 +3246,7 @@ __metadata:
     "@types/node": ^18.11.18
     jest: ^27.4.5
     npm-run-all: ^4.1.5
-    rollup: ^2.18.2
+    rollup: ^2.52.7
     typedoc: 0.23.24
     typescript: 4.9.4
     unist-util-visit: ^2.0.3
@@ -3310,7 +3309,7 @@ __metadata:
     babel-jest: ^27.5.1
     jest: ^27.4.5
     npm-run-all: ^4.1.5
-    rollup: 2.33.1
+    rollup: ^2.52.7
     typedoc: 0.23.24
     typescript: 4.9.4
   languageName: unknown
@@ -6580,7 +6579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.1.2, fsevents@npm:~2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -6590,7 +6589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
   dependencies:
@@ -8498,7 +8497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:0.25.7, magic-string@npm:^0.25.0, magic-string@npm:^0.25.3":
+"magic-string@npm:0.25.7, magic-string@npm:^0.25.0":
   version: 0.25.7
   resolution: "magic-string@npm:0.25.7"
   dependencies:
@@ -10461,35 +10460,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-inject@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "rollup-plugin-inject@npm:3.0.2"
-  dependencies:
-    estree-walker: ^0.6.1
-    magic-string: ^0.25.3
-    rollup-pluginutils: ^2.8.1
-  checksum: a014972c80fe34b8c8154056fa2533a8440066a31de831e3793fc21b15d108d92c22d8f7f472397bd5783d7c5e04d8cbf112fb72c5a26e997726e4eb090edad1
-  languageName: node
-  linkType: hard
-
-"rollup-plugin-node-polyfills@npm:0.2.1":
-  version: 0.2.1
-  resolution: "rollup-plugin-node-polyfills@npm:0.2.1"
-  dependencies:
-    rollup-plugin-inject: ^3.0.0
-  checksum: e84645212c443aca3cfae2ba69f01c6d8c5c250f0bf651416b69a4572b60aae9da7cdd687de3ab9b903f7a1ab96b06b71f0c4927d1b02a37485360d2b563937b
-  languageName: node
-  linkType: hard
-
-"rollup-plugin-require-context@npm:0.0.2":
-  version: 0.0.2
-  resolution: "rollup-plugin-require-context@npm:0.0.2"
-  dependencies:
-    rollup-pluginutils: ^2.0.1
-  checksum: 321acdb5222af55341753beadb61a5f6235ebd50a09c10741bef8df96b6eb3354356b8220bda7dfdf663a936ac7d316db1e9e30c51309d05a24cb9a78df0d8af
-  languageName: node
-  linkType: hard
-
 "rollup-plugin-string@npm:3.0.0":
   version: 3.0.0
   resolution: "rollup-plugin-string@npm:3.0.0"
@@ -10513,7 +10483,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-pluginutils@npm:^2.0.1, rollup-pluginutils@npm:^2.4.1, rollup-pluginutils@npm:^2.8.1":
+"rollup-pluginutils@npm:^2.4.1":
   version: 2.8.2
   resolution: "rollup-pluginutils@npm:2.8.2"
   dependencies:
@@ -10522,37 +10492,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:2.33.1":
-  version: 2.33.1
-  resolution: "rollup@npm:2.33.1"
-  dependencies:
-    fsevents: ~2.1.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: b9c869bd24cb02d950b8665af6ba592219c68787227bb856ba54753181b1e150f2c96d27f8911dced051c5a0d6fc22dc51a782e98dec64e31dcf7096dc67ff1c
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.18.2":
-  version: 2.23.0
-  resolution: "rollup@npm:2.23.0"
-  dependencies:
-    fsevents: ~2.1.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: a65b796ec98c4feae96973ab7702edf8b2043d7252dbfc619f2cc4a563e934725a4b9df13a9399fb375130b9a0bf587cd6a9db6736bee8df4ee41c2933946647
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.43.1":
-  version: 2.77.2
-  resolution: "rollup@npm:2.77.2"
+"rollup@npm:^2.43.1, rollup@npm:^2.52.7":
+  version: 2.79.1
+  resolution: "rollup@npm:2.79.1"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -10560,21 +10502,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 5a84fb98a6f858906bceba091430442f6c1f362b07c5fa9123b708f87e39f52640e34a189cd9a1776ceae61300055c78ba648205fa03188451539ebeb19797df
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.52.7":
-  version: 2.52.7
-  resolution: "rollup@npm:2.52.7"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 92629c518c234f5f02249ed225fdb8c0bc25039ee91e3713107bf3b859344b81d986cbad71d793b6a973d852a495c2e5352c9d628eae992818036c0b45ea843c
+  checksum: 6a2bf167b3587d4df709b37d149ad0300692cc5deb510f89ac7bdc77c8738c9546ae3de9322b0968e1ed2b0e984571f5f55aae28fa7de4cfcb1bc5402a4e2be6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,11 +3138,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eventstore-ui/forms@workspace:packages/forms"
   dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/components": "workspace:*"
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
     "@stencil/core": 3.0.0
     "@types/jest": ^27.0.3
+    babel-jest: ^27.5.1
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     rollup: ^2.52.7
@@ -3225,10 +3229,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eventstore-ui/router@workspace:packages/router"
   dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/utils": "workspace:*"
     "@stencil/core": 3.0.0
     "@types/jest": ^27.0.3
+    babel-jest: ^27.5.1
     jest: ^27.4.5
+    rollup: ^2.52.7
     typedoc: 0.23.24
     typescript: 4.9.4
   peerDependencies:
@@ -3259,9 +3268,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eventstore-ui/stores@workspace:packages/stores"
   dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/utils": "workspace:*"
     "@stencil/core": 3.0.0
     "@types/jest": ^27.0.3
+    babel-jest: ^27.5.1
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     rollup: ^2.52.7
@@ -3276,9 +3289,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eventstore-ui/theme@workspace:packages/theme"
   dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-typescript": ^7.12.7
     "@eventstore-ui/utils": "workspace:*"
     "@stencil/core": 3.0.0
+    babel-jest: ^27.5.1
     jest: ^27.4.5
+    rollup: ^2.52.7
     typedoc: 0.23.24
     typescript: 4.9.4
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,12 +3014,12 @@ __metadata:
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
     "@floating-ui/dom": 0.4.1
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     jest: ^27.4.5
     npm-run-all: ^4.1.5
-    puppeteer: 10.4.0
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    puppeteer: ^19.5.0
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/router": 0.1.x
     "@eventstore-ui/theme": 0.1.x
@@ -3032,14 +3032,14 @@ __metadata:
   resolution: "@eventstore-ui/configs@workspace:tools/configs"
   dependencies:
     "@eventstore-ui/assets": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     "@stencil/postcss": ^2.1.0
     "@typescript-eslint/eslint-plugin": ^5.6.0
     "@typescript-eslint/parser": ^5.6.0
     eslint: ^8.4.0
     postcss-preset-env: 6.7.0
     prettier: ^2.2.1
-    typescript: 4.5.5
+    typescript: 4.9.4
   peerDependencies:
     "@typescript-eslint/eslint-plugin": ^5.x.x
     "@typescript-eslint/parser": ^5.x.x
@@ -3064,7 +3064,7 @@ __metadata:
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     "@stencil/postcss": ^2.1.0
     "@types/jest": ^27.0.3
     "@types/markdown-it": 12.0.3
@@ -3077,14 +3077,14 @@ __metadata:
     npm-run-all: ^4.1.5
     postcss-preset-env: 6.7.0
     prettier: 2.2.1
-    puppeteer: 10.4.0
+    puppeteer: ^19.5.0
     rollup: 2.33.1
     rollup-plugin-node-polyfills: 0.2.1
     rollup-plugin-require-context: 0.0.2
     rollup-plugin-string: 3.0.0
     serve: 14.0.1
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
     workbox-build: 6.5.4
   languageName: unknown
   linkType: soft
@@ -3097,14 +3097,14 @@ __metadata:
     "@eventstore-ui/configs": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     jest: ^27.4.5
     monaco-editor: ^0.22.3
     npm-run-all: ^4.1.5
-    puppeteer: 10.4.0
+    puppeteer: ^19.5.0
     rollup: 2.33.1
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/components": 0.1.x
     "@eventstore-ui/theme": 0.1.x
@@ -3121,13 +3121,13 @@ __metadata:
     "@eventstore-ui/icon-manager": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     imask: 6.0.5
     jest: ^27.4.5
     npm-run-all: ^4.1.5
-    puppeteer: 10.4.0
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    puppeteer: ^19.5.0
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/components": 0.1.x
     "@eventstore-ui/theme": 0.1.x
@@ -3142,13 +3142,13 @@ __metadata:
     "@eventstore-ui/components": "workspace:*"
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     rollup: ^2.52.7
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/components": 0.1.x
     "@eventstore-ui/stores": 0.1.x
@@ -3160,7 +3160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eventstore-ui/icon-manager@workspace:tools/icon-manager"
   dependencies:
-    "@types/node": ^16.11.9
+    "@types/node": ^18.11.18
     "@types/semver": ^7.3.9
     "@types/svgo": ^2.6.3
     case-anything: ^2.1.10
@@ -3169,7 +3169,7 @@ __metadata:
     prettier: ^2.2.1
     semver: ^7.3.5
     svgo: ^2.8.0
-    typescript: 4.5.5
+    typescript: 4.9.4
     yargs: ^15.3.1
   bin:
     icon: ./dist/index.js
@@ -3181,15 +3181,15 @@ __metadata:
   resolution: "@eventstore-ui/illustrations@workspace:packages/illustrations"
   dependencies:
     "@eventstore-ui/theme": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     case-anything: ^2.1.10
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     prettier: ^2.2.1
-    puppeteer: 10.4.0
+    puppeteer: ^19.5.0
     svgo: ^2.8.0
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
     yargs: ^15.3.1
   peerDependencies:
     "@eventstore-ui/theme": 0.1.x
@@ -3207,12 +3207,12 @@ __metadata:
     "@eventstore-ui/router": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     jest: ^27.4.5
     npm-run-all: ^4.1.5
-    puppeteer: 10.4.0
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    puppeteer: ^19.5.0
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/components": 0.1.x
     "@eventstore-ui/illustrations": 0.1.x
@@ -3227,11 +3227,11 @@ __metadata:
   resolution: "@eventstore-ui/router@workspace:packages/router"
   dependencies:
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     "@types/jest": ^27.0.3
     jest: ^27.4.5
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/utils": 0.1.x
   languageName: unknown
@@ -3243,13 +3243,13 @@ __metadata:
   dependencies:
     "@mdx-js/mdx": ^1.6.22
     "@rollup/pluginutils": ^3.1.0
-    "@stencil/core": 2.17.4
-    "@types/node": ^16.11.9
+    "@stencil/core": 3.0.0
+    "@types/node": ^18.11.18
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     rollup: ^2.18.2
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
     unist-util-visit: ^2.0.3
   peerDependencies:
     "@stencil/core": 2.x
@@ -3261,13 +3261,13 @@ __metadata:
   resolution: "@eventstore-ui/stores@workspace:packages/stores"
   dependencies:
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     rollup: ^2.52.7
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/utils": 0.1.x
   languageName: unknown
@@ -3278,10 +3278,10 @@ __metadata:
   resolution: "@eventstore-ui/theme@workspace:packages/theme"
   dependencies:
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
     jest: ^27.4.5
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     "@eventstore-ui/utils": 0.1.x
   languageName: unknown
@@ -3291,9 +3291,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@eventstore-ui/typedoc-plugin-usage@workspace:tools/typedoc-plugin-usage"
   dependencies:
-    "@types/node": ^16.11.9
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    "@types/node": ^18.11.18
+    typedoc: 0.23.24
+    typescript: 4.9.4
   peerDependencies:
     typedoc: ">=0.21.0"
   languageName: unknown
@@ -3311,8 +3311,8 @@ __metadata:
     jest: ^27.4.5
     npm-run-all: ^4.1.5
     rollup: 2.33.1
-    typedoc: ^0.22.13
-    typescript: 4.5.5
+    typedoc: 0.23.24
+    typescript: 4.9.4
   languageName: unknown
   linkType: soft
 
@@ -3828,12 +3828,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/core@npm:2.17.4":
-  version: 2.17.4
-  resolution: "@stencil/core@npm:2.17.4"
+"@stencil/core@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@stencil/core@npm:3.0.0"
   bin:
     stencil: bin/stencil
-  checksum: cb7496a58fb040dd91ca451f3c54041bb387cf6e81fb60d17650646d1d1ee62fc0badea10d74b6ecc1ac3de5c36063c7ce556a860044727be7001a22a08660f2
+  checksum: 1396d1e68686d9cb646b07e844523602d09a29d837627fd3a46fbaf806331872181a61a47bba3efd68f9486e140c1bf72d20a73ab5922f1c4dc4a37d99c308b2
   languageName: node
   linkType: hard
 
@@ -4053,17 +4053,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 14.0.27
-  resolution: "@types/node@npm:14.0.27"
-  checksum: 8068203dc89c6319961a2cc9134f6be719728c78835aeec31e4972ac262d20d625b6ac617b1479223188c173da5c480001d212a0780a49a44058c4ae4ea28f2f
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^16.11.9":
-  version: 16.11.11
-  resolution: "@types/node@npm:16.11.11"
-  checksum: 1c472bd63f23ca0e4effc96e6e0c693b83b027f613a1f41b6d1bd7791f65ce171a351e0a5c92575cb59e84ad0a930875397bfbbb91a7c925ddbbb558f7461af8
+"@types/node@npm:*, @types/node@npm:^18.11.18":
+  version: 18.11.18
+  resolution: "@types/node@npm:18.11.18"
+  checksum: 03f17f9480f8d775c8a72da5ea7e9383db5f6d85aa5fefde90dd953a1449bd5e4ffde376f139da4f3744b4c83942166d2a7603969a6f8ea826edfb16e6e3b49d
   languageName: node
   linkType: hard
 
@@ -4820,7 +4813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.1, bl@npm:^4.0.3":
+"bl@npm:^4.0.3":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -5022,9 +5015,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001097, caniuse-lite@npm:^1.0.30001272, caniuse-lite@npm:^1.0.30001370":
-  version: 1.0.30001373
-  resolution: "caniuse-lite@npm:1.0.30001373"
-  checksum: cd2f027e2fcf66ed3b0e3eccec89df871f951f2e7600944fae2c3f6f1c37ac82392e573c279e15bf851b75f9696472e38d33fd52d964819ffb8af7af4078ceba
+  version: 1.0.30001449
+  resolution: "caniuse-lite@npm:1.0.30001449"
+  checksum: f1b395f0a5495c1931c53f58441e0db79b8b0f8ef72bb6d241d13c49b05827630efe6793d540610e0a014d8fdda330dd42f981c82951bd4bdcf635480e1a0102
   languageName: node
   linkType: hard
 
@@ -5410,6 +5403,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:8.0.0":
+  version: 8.0.0
+  resolution: "cosmiconfig@npm:8.0.0"
+  dependencies:
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+  checksum: ff4cdf89ac1ae52e7520816622c21a9e04380d04b82d653f5139ec581aa4f7f29e096d46770bc76c4a63c225367e88a1dfa233ea791669a35101f5f9b972c7d1
+  languageName: node
+  linkType: hard
+
+"cross-fetch@npm:3.1.5":
+  version: 3.1.5
+  resolution: "cross-fetch@npm:3.1.5"
+  dependencies:
+    node-fetch: 2.6.7
+  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -5591,15 +5605,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.3.1":
-  version: 4.3.1
-  resolution: "debug@npm:4.3.1"
+"debug@npm:4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
   dependencies:
     ms: 2.1.2
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 2c3352e37d5c46b0d203317cd45ea0e26b2c99f2d9dfec8b128e6ceba90dfb65425f5331bf3020fe9929d7da8c16758e737f4f3bfc0fce6b8b3d503bae03298b
+  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
   languageName: node
   linkType: hard
 
@@ -5732,10 +5746,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.901419":
-  version: 0.0.901419
-  resolution: "devtools-protocol@npm:0.0.901419"
-  checksum: de68331ddfb35b828ad743d939d9237e122f76d4a6cbf1e64f6c6d8e9c2c5cc65a5f1994db0fead90192cca1aa9dbed2ea822a7da7b58104cd041a90e215b9a3
+"devtools-protocol@npm:0.0.1082910":
+  version: 0.0.1082910
+  resolution: "devtools-protocol@npm:0.0.1082910"
+  checksum: 62b95b58f33c09412ea715826a184b81f5afe10c63945d444bf18f8455b0eaf16e5a4c4aa0a1f797f710e36b8e2d31c32938084371967662a51043fa9ebddd80
   languageName: node
   linkType: hard
 
@@ -6509,7 +6523,7 @@ __metadata:
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/theme": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
   languageName: unknown
   linkType: soft
 
@@ -6776,20 +6790,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "glob@npm:7.2.0"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -7044,7 +7044,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:5.0.0, https-proxy-agent@npm:^5.0.0":
+"https-proxy-agent@npm:5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: 6
+    debug: 4
+  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "https-proxy-agent@npm:5.0.0"
   dependencies:
@@ -8306,17 +8316,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.2.0":
+"jsonc-parser@npm:3.2.0, jsonc-parser@npm:^3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
-  languageName: node
-  linkType: hard
-
-"jsonc-parser@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "jsonc-parser@npm:3.0.0"
-  checksum: 1df2326f1f9688de30c70ff19c5b2a83ba3b89a1036160da79821d1361090775e9db502dc57a67c11b56e1186fc1ed70b887f25c5febf9a3ec4f91435836c99d
   languageName: node
   linkType: hard
 
@@ -8587,12 +8590,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.0.12":
-  version: 4.0.12
-  resolution: "marked@npm:4.0.12"
+"marked@npm:^4.2.5":
+  version: 4.2.12
+  resolution: "marked@npm:4.2.12"
   bin:
     marked: bin/marked.js
-  checksum: 7575117f85a8986652f3ac8b8a7b95056c4c5fce01a1fc76dc4c7960412cb4c9bd9da8133487159b6b3ff84f52b543dfe9a36f826a5f358892b5ec4b6824f192
+  checksum: bd551cd61028ee639d4ca2ccdfcc5a6ba4227c1b143c4538f3cde27f569dcb57df8e6313560394645b418b84a7336c07ab1e438b89b6324c29d7d8cdd3102d63
   languageName: node
   linkType: hard
 
@@ -8767,7 +8770,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
+"minimatch@npm:^5.1.2":
+  version: 5.1.6
+  resolution: "minimatch@npm:5.1.6"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.0":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
@@ -8851,14 +8863,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.1":
-  version: 0.5.5
-  resolution: "mkdirp@npm:0.5.5"
-  dependencies:
-    minimist: ^1.2.5
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 3bce20ea525f9477befe458ab85284b0b66c8dc3812f94155af07c827175948cdd8114852ac6c6d82009b13c1048c37f6d98743eb019651ee25c39acc8aabe7d
+"mkdirp-classic@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
   languageName: node
   linkType: hard
 
@@ -8931,7 +8939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.1":
+"node-fetch@npm:2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
@@ -9330,7 +9338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^5.2.0":
+"parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
   dependencies:
@@ -9472,7 +9480,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pkg-dir@npm:4.2.0, pkg-dir@npm:^4.2.0":
+"pkg-dir@npm:^4.2.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
   dependencies:
@@ -9910,14 +9918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:2.0.1":
-  version: 2.0.1
-  resolution: "progress@npm:2.0.1"
-  checksum: 46d1f5a5df9c331f6402d856a4239f90a8fde8f9fcff0426ceb4edca7a7a3b4256d83adcfb3d4176a1dd239536a43e547bd0f325f5e8c4ac2881169361028426
-  languageName: node
-  linkType: hard
-
-"progress@npm:^2.0.0":
+"progress@npm:2.0.3, progress@npm:^2.0.0":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
@@ -9998,23 +9999,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer@npm:10.4.0":
-  version: 10.4.0
-  resolution: "puppeteer@npm:10.4.0"
+"puppeteer-core@npm:19.6.2":
+  version: 19.6.2
+  resolution: "puppeteer-core@npm:19.6.2"
   dependencies:
-    debug: 4.3.1
-    devtools-protocol: 0.0.901419
+    cross-fetch: 3.1.5
+    debug: 4.3.4
+    devtools-protocol: 0.0.1082910
     extract-zip: 2.0.1
-    https-proxy-agent: 5.0.0
-    node-fetch: 2.6.1
-    pkg-dir: 4.2.0
-    progress: 2.0.1
+    https-proxy-agent: 5.0.1
     proxy-from-env: 1.1.0
     rimraf: 3.0.2
-    tar-fs: 2.0.0
-    unbzip2-stream: 1.3.3
-    ws: 7.4.6
-  checksum: 3b7b628f07b3e1f960110691363c1eb07a485fa2f24b5a083558a56841cc46bfcac7a3ab8ae5c687f39621972b35327ce934ea731c831dcd8b75d897920bdc26
+    tar-fs: 2.1.1
+    unbzip2-stream: 1.4.3
+    ws: 8.11.0
+  checksum: 92325f78de3e468a2444136012806ad9b0b1c694b3647022e71aa3f04b776781a9241b9b7984e5c7800acc4c9cfc3176752da37bcca7cb2a8c92e6e3e6c65be4
+  languageName: node
+  linkType: hard
+
+"puppeteer@npm:^19.5.0":
+  version: 19.6.2
+  resolution: "puppeteer@npm:19.6.2"
+  dependencies:
+    cosmiconfig: 8.0.0
+    https-proxy-agent: 5.0.1
+    progress: 2.0.3
+    proxy-from-env: 1.1.0
+    puppeteer-core: 19.6.2
+  checksum: 7ed12a8be7d243d82d4569e3f30fe376b96515b88562cbd6dca60e9fc052b232669db736666c9212d4d23366ed30764e3f5a6633e1195cf0709cba49771a8fa2
   languageName: node
   linkType: hard
 
@@ -10577,7 +10589,7 @@ __metadata:
     npm-run-all: ^4.1.5
     nx: 15.5.1
     prettier: ^2.2.1
-    typescript: 4.5.5
+    typescript: 4.9.4
   languageName: unknown
   linkType: soft
 
@@ -10586,7 +10598,7 @@ __metadata:
   resolution: "router-demo@workspace:demos/router-demo"
   dependencies:
     "@eventstore-ui/router": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
   languageName: unknown
   linkType: soft
 
@@ -10777,14 +10789,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "shiki@npm:0.10.1"
+"shiki@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "shiki@npm:0.12.1"
   dependencies:
-    jsonc-parser: ^3.0.0
-    vscode-oniguruma: ^1.6.1
-    vscode-textmate: 5.2.0
-  checksum: fb746f3cb3de7e545e3b10a6cb658d3938f840e4ccc9a3c90ceb7e69a8f89dbb432171faac1e9f02a03f103684dad88ee5e54b5c4964fa6b579fca6e8e26424d
+    jsonc-parser: ^3.2.0
+    vscode-oniguruma: ^1.7.0
+    vscode-textmate: ^8.0.0
+  checksum: a5d78a79d282f5c5168786980c66e82f075e91fa015097456486624fc5775688d685ad9b1972b0617d7f1ef50927d21b61dca476247a6f6c6b7042046e89a979
   languageName: node
   linkType: hard
 
@@ -11005,7 +11017,7 @@ __metadata:
   dependencies:
     "@eventstore-ui/stores": "workspace:*"
     "@eventstore-ui/utils": "workspace:*"
-    "@stencil/core": 2.17.4
+    "@stencil/core": 3.0.0
   languageName: unknown
   linkType: soft
 
@@ -11306,32 +11318,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:2.0.0":
-  version: 2.0.0
-  resolution: "tar-fs@npm:2.0.0"
+"tar-fs@npm:2.1.1":
+  version: 2.1.1
+  resolution: "tar-fs@npm:2.1.1"
   dependencies:
     chownr: ^1.1.1
-    mkdirp: ^0.5.1
+    mkdirp-classic: ^0.5.2
     pump: ^3.0.0
-    tar-stream: ^2.0.0
-  checksum: f15079cd7e5b38b7982d3a1c2f0cf0eac58e1c622f0191b12d90440a4e97ea0f63bf31467f6ad9cb5ffdd47d9fc251682f9456e36c6d5e2488f49f14a9d28a75
+    tar-stream: ^2.1.4
+  checksum: f5b9a70059f5b2969e65f037b4e4da2daf0fa762d3d232ffd96e819e3f94665dbbbe62f76f084f1acb4dbdcce16c6e4dac08d12ffc6d24b8d76720f4d9cf032d
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^2.0.0":
-  version: 2.1.3
-  resolution: "tar-stream@npm:2.1.3"
-  dependencies:
-    bl: ^4.0.1
-    end-of-stream: ^1.4.1
-    fs-constants: ^1.0.0
-    inherits: ^2.0.3
-    readable-stream: ^3.1.1
-  checksum: 71025989746dbaade17f7e75e4e1323602185b32049ddcb21ea9e0e4a7a474f73513236cce2860ce67c99ddd576a11369afaec245c259d265d28385ab2662188
-  languageName: node
-  linkType: hard
-
-"tar-stream@npm:~2.2.0":
+"tar-stream@npm:^2.1.4, tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:
@@ -11613,40 +11612,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:^0.22.13":
-  version: 0.22.13
-  resolution: "typedoc@npm:0.22.13"
+"typedoc@npm:0.23.24":
+  version: 0.23.24
+  resolution: "typedoc@npm:0.23.24"
   dependencies:
-    glob: ^7.2.0
     lunr: ^2.3.9
-    marked: ^4.0.12
-    minimatch: ^5.0.1
-    shiki: ^0.10.1
+    marked: ^4.2.5
+    minimatch: ^5.1.2
+    shiki: ^0.12.1
   peerDependencies:
-    typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
   bin:
     typedoc: bin/typedoc
-  checksum: e453114fbbb5e3e366bcfde40fc3f7d76a038dbc3953e6cc9c9dd8f9747048ed77c2d082671e91537fb26bb11f7fc5846f9568262adf0087b328b3f96a47a85a
+  checksum: b04f9afcba9a38d35631b08ca345f52700f9138f59b9729d7bfecf127c2a75dd6a053594db68f3141e4d7e63b701ffa5421cbdeb95f86b254257e05e240f4da0
   languageName: node
   linkType: hard
 
-"typescript@npm:4.5.5":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
+"typescript@npm:4.9.4":
+  version: 4.9.4
+  resolution: "typescript@npm:4.9.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  checksum: e782fb9e0031cb258a80000f6c13530288c6d63f1177ed43f770533fdc15740d271554cdae86701c1dd2c83b082cea808b07e97fd68b38a172a83dbf9e0d0ef9
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.5.5#~builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=ddd1e8"
+"typescript@patch:typescript@4.9.4#~builtin<compat/typescript>":
+  version: 4.9.4
+  resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9cdde4aae20b2904431f3f2ca8acaf3b0cc52faddf68aa88b288c9d0520221817da43783a756fce7ab9360033ada0371c3ff93dfc4bdb4b13f6e9bac64e1658d
+  checksum: 37f6e2c3c5e2aa5934b85b0fddbf32eeac8b1bacf3a5b51d01946936d03f5377fe86255d4e5a4ae628fd0cd553386355ad362c57f13b4635064400f3e8e05b9d
   languageName: node
   linkType: hard
 
@@ -11669,13 +11667,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unbzip2-stream@npm:1.3.3":
-  version: 1.3.3
-  resolution: "unbzip2-stream@npm:1.3.3"
+"unbzip2-stream@npm:1.4.3":
+  version: 1.4.3
+  resolution: "unbzip2-stream@npm:1.4.3"
   dependencies:
     buffer: ^5.2.1
     through: ^2.3.8
-  checksum: 5ae179e60971023c1ee2be2d3f02dd81e4dae8c506fe2367f63a2c126073c2f08c101005d328c34b13cb1d691627e4c6c528d1e273ea3a3dda15d906bac66391
+  checksum: 0e67c4a91f4fa0fc7b4045f8b914d3498c2fc2e8c39c359977708ec85ac6d6029840e97f508675fdbdf21fcb8d276ca502043406f3682b70f075e69aae626d1d
   languageName: node
   linkType: hard
 
@@ -12008,17 +12006,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-oniguruma@npm:^1.6.1":
-  version: 1.6.2
-  resolution: "vscode-oniguruma@npm:1.6.2"
-  checksum: 6b754acdafd5b68242ea5938bb00a32effc16c77f471d4f0f337d879d0e8e592622998e2441f42d9a7ff799c1593f31c11f26ca8d9bf9917e3ca881d3c1f3e19
+"vscode-oniguruma@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "vscode-oniguruma@npm:1.7.0"
+  checksum: 53519d91d90593e6fb080260892e87d447e9b200c4964d766772b5053f5699066539d92100f77f1302c91e8fc5d9c772fbe40fe4c90f3d411a96d5a9b1e63f42
   languageName: node
   linkType: hard
 
-"vscode-textmate@npm:5.2.0":
-  version: 5.2.0
-  resolution: "vscode-textmate@npm:5.2.0"
-  checksum: 5449b42d451080f6f3649b66948f4b5ee4643c4e88cfe3558a3b31c84c78060cfdd288c4958c1690eaa5cd65d09992fa6b7c3bef9d4aa72b3651054a04624d20
+"vscode-textmate@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "vscode-textmate@npm:8.0.0"
+  checksum: 127780dfea89559d70b8326df6ec344cfd701312dd7f3f591a718693812b7852c30b6715e3cfc8b3200a4e2515b4c96f0843c0eacc0a3020969b5de262c2a4bb
   languageName: node
   linkType: hard
 
@@ -12435,9 +12433,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:7.4.6":
-  version: 7.4.6
-  resolution: "ws@npm:7.4.6"
+"ws@npm:8.11.0":
+  version: 8.11.0
+  resolution: "ws@npm:8.11.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -12446,7 +12444,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 3a990b32ed08c72070d5e8913e14dfcd831919205be52a3ff0b4cdd998c8d554f167c9df3841605cde8b11d607768cacab3e823c58c96a5c08c987e093eb767a
+  checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Dependency updates and breaking changes 
- `@stencil/core`
-  `puppeteer`
- `typedoc`
- `typescript`

Update docs to work with latest typedoc 
- fix changes in typedoc JSON mappings
- replace contextRequires with imports
- Make rollup versions consistent

Testing updates 
- Only run tests with stencil if stencil is used.
- Update store tests to work with jest 27
