### PR TITLE
Support `unknown` in errorState of `Page`

### DIFF
--- a/packages/layout/src/components/Page/Page.tsx
+++ b/packages/layout/src/components/Page/Page.tsx
@@ -8,10 +8,10 @@ import {
 import { PageTitle } from '@eventstore-ui/router';
 import { setProgress } from '../es-loading-bar/utils/setProgress';
 
-export type PageState = 'loading' | 'ready' | Error;
+export type PageState = 'loading' | 'ready' | ['error', unknown];
 
 export interface ErrorStateProps {
-    error: Error;
+    error: unknown;
 }
 
 export interface PageProps {
@@ -101,7 +101,7 @@ const PageBody: FunctionalComponent<PageProps> = (
 ) => {
     updateState(progressBarId, state);
     if (state === 'loading') return <LoadingState />;
-    if (state instanceof Error) return <ErrorState error={state} />;
+    if (Array.isArray(state)) return <ErrorState error={state[1]} />;
     if (empty) return <EmptyState />;
     return (
         <>

--- a/packages/layout/src/components/dev-root/dev-root.demo.tsx
+++ b/packages/layout/src/components/dev-root/dev-root.demo.tsx
@@ -94,7 +94,7 @@ export class DevRoot {
                     <Route url={'/error'}>
                         <Page
                             pageTitle={'Error Test'}
-                            state={new Error('Oh no!')}
+                            state={['error', new Error('Oh no!')]}
                         >
                             <div>{'hello'}</div>
                         </Page>


### PR DESCRIPTION
Now that typescript [defaults to `unknown` in Catch Variables ](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables), we want to be able to take `unknown` as an error state in `PageState`.



As `unknown` overtakes unions, causing them to be unknown:

```ts
// This would mean that PageState is now just "unknown" :(
export type PageState = 'loading' | 'ready' | unknown;
``` 

We are using a tuple for the error:

```ts
export type PageState = 'loading' | 'ready' | ['error', unknown];
``` 

which allows us to continue to narrow the type, though it looks a little odd.