### PR TITLE
Fix strange es-select / es-typeahead behaviour in Safari

### DIFF
--- a/packages/fields/src/components/es-select/demo/es-select-option.demo.tsx
+++ b/packages/fields/src/components/es-select/demo/es-select-option.demo.tsx
@@ -1,0 +1,21 @@
+import { Component, h, Host, Prop } from '@stencil/core';
+import { ICON_NAMESPACE } from '../../../icons/namespace';
+
+/** used in the es-select demo. */
+@Component({
+    tag: 'es-select-option-demo',
+    shadow: true,
+})
+export class Demo {
+    @Prop() name: string = 'Trash';
+    @Prop() value: string = 'trash';
+
+    render() {
+        return (
+            <Host style={{ padding: '2px', display: 'flex', gap: '10px' }}>
+                <es-icon icon={[ICON_NAMESPACE, this.value]} />
+                {this.name}
+            </Host>
+        );
+    }
+}

--- a/packages/fields/src/components/es-select/demo/es-select.demo.tsx
+++ b/packages/fields/src/components/es-select/demo/es-select.demo.tsx
@@ -1,0 +1,66 @@
+import { Component, h, Host, Listen, State } from '@stencil/core';
+import type { FieldChangeEvent } from '../../../types';
+import type { RenderSelectOption } from '../types';
+
+/** es-select demo. */
+@Component({
+    tag: 'es-select-demo',
+    shadow: true,
+})
+export class Demo {
+    @State() value: string | null = null;
+
+    @Listen('fieldchange')
+    onChange(e: FieldChangeEvent<string>) {
+        this.value = e.detail.value;
+    }
+
+    render() {
+        return (
+            <Host style={{ padding: '10px', display: 'block' }}>
+                <es-select
+                    label="hello"
+                    name="hello"
+                    options={this.options}
+                    value={this.value}
+                    renderOption={this.renderOption}
+                />
+            </Host>
+        );
+    }
+
+    private renderOption: RenderSelectOption = (_, { name, value }) => (
+        <es-select-option-demo name={name} value={value} />
+    );
+
+    private options = [
+        {
+            name: 'check',
+            value: 'check',
+        },
+        {
+            name: 'chevron',
+            value: 'chevron',
+        },
+        {
+            name: 'error',
+            value: 'error',
+        },
+        {
+            name: 'info',
+            value: 'info',
+        },
+        {
+            name: 'plus',
+            value: 'plus',
+        },
+        {
+            name: 'trash',
+            value: 'trash',
+        },
+        {
+            name: 'warning',
+            value: 'warning',
+        },
+    ];
+}

--- a/packages/fields/src/components/es-typeahead/es-typeahead.css
+++ b/packages/fields/src/components/es-typeahead/es-typeahead.css
@@ -127,6 +127,15 @@ es-typeahead {
     }
 }
 
+/* 
+    Safari gets confused if a button's child is a component,
+    So we disable the pointer events on a button's child to ensure
+    that the click comes from the button.
+*/
+.option > * {
+    pointer-events: none;
+}
+
 .list[high-contrast] .option {
     &:hover {
         --background-color: transparent;


### PR DESCRIPTION
Safari gets confused if a button's child is a component, so we disable the pointer events on a button's child to ensure that the click comes from the button.


https://user-images.githubusercontent.com/11861797/219647339-a9149e6f-a8ff-41ad-8d1d-f3dc06471650.mov



fixes: #295
