### PR TITLE
Fix `es-sidebar-dropdown` and `es-header-dropdown` toggling

### DIFF
--- a/packages/components/src/components/es-popover/es-popover.tsx
+++ b/packages/components/src/components/es-popover/es-popover.tsx
@@ -134,9 +134,7 @@ export class Popover {
         }
     }
 
-    @Listen('click', { target: 'document', capture: true }) onClickOutside(
-        e: MouseEvent,
-    ) {
+    @Listen('click', { target: 'document' }) onClickOutside(e: MouseEvent) {
         if (!this.closeOnClickOutside) return;
         if (!this.open || !this.popperInner) return;
         const path = e.composedPath();


### PR DESCRIPTION
`es-popover`'s `closeOnClickOutside` was firing in the capture phase, preventing control from usage.

fixes: #298 