### PR TITLE
Align radioOption with typeaheadOption

### DIFF
--- a/packages/fields/src/components/es-radio-card-group/es-radio-card-group.tsx
+++ b/packages/fields/src/components/es-radio-card-group/es-radio-card-group.tsx
@@ -67,20 +67,20 @@ export class RadioCardGroup {
                         )}
                         <div class={'group-inner'}>
                             {group.map((option) => {
-                                const active = option.id === this.value;
+                                const active = option.value === this.value;
                                 return (
                                     <label
                                         class={{
                                             active,
                                             disabled: !!option.disabled,
                                         }}
-                                        htmlFor={`${this.name}-${option.id}`}
+                                        htmlFor={`${this.name}-${option.value}`}
                                     >
                                         <input
                                             type={'radio'}
-                                            id={`${this.name}-${option.id}`}
+                                            id={`${this.name}-${option.value}`}
                                             name={this.name}
-                                            value={option.id}
+                                            value={option.value}
                                             checked={active}
                                             onChange={this.handleChange}
                                             disabled={option.disabled}

--- a/packages/fields/src/components/es-radio-card-group/types.ts
+++ b/packages/fields/src/components/es-radio-card-group/types.ts
@@ -2,8 +2,8 @@ import type { RenderFunction } from '../../types';
 
 /** An option to be selected */
 export interface RadioCardGroupOption {
-    /** The id of the option, to be used as its value. */
-    id: string;
+    /** The string to be used as a value. */
+    value: string;
     /** A name to display. */
     name: string;
     /** A longer description to be displayed. */


### PR DESCRIPTION
`typeahead` and `select` use the more standard `name` / `value` whereas `radioGroup` currently uses `id`/`value`. 
This PR aligns those options.