### PR TITLE
Add use() to ListStore to allow for plugins

### DIFF
--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -9,7 +9,9 @@ export {
 
 export {
     persistLocally,
+    persistListLocally,
     PersistLocallyOptions,
+    PersistListLocallyOptions,
 } from './plugins/persistLocally';
 
 export type { Plugin, Subscription } from './types';

--- a/packages/stores/src/plugins/persistLocally.ts
+++ b/packages/stores/src/plugins/persistLocally.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@stencil/core/internal';
-import type { Plugin } from '../types';
-import type { Store } from '..';
+import type { ListStorePlugin, Plugin } from '../types';
+import type { Store } from '../stores/createStore';
 export type PersistLocallyOptions<T> = {
     /** Store keys to be persisted locally. */
     keys?: Array<keyof T>;
@@ -12,6 +12,13 @@ export type PersistLocallyOptions<T> = {
     deserialize?: (s: string) => Partial<T>;
     /** The logger. */
     logger?: Logger;
+};
+
+export type PersistListLocallyOptions<T> = PersistLocallyOptions<T> & {
+    /** Serializer method to handle data conversion from browser storage to list store. */
+    deserialisze?: (s: string) => Record<string, T>;
+    /** Deserializer method to handle data conversion from list store to browser storage. */
+    serialize?: (d: Record<string, T>) => string;
 };
 
 /** Persist store content to browser storage. */
@@ -60,6 +67,74 @@ export const persistLocally = <T>(
         debounce = setTimeout(() => {
             try {
                 const data = filterKeys(store.state);
+                storage.setItem(storageKey, serialize(data));
+            } catch (error) {
+                options.logger?.error(error);
+            }
+        });
+    };
+    if (!storage.getItem(storageKey)) {
+        persistToStorage();
+    } else {
+        readFromStorage();
+    }
+    globalThis.addEventListener(
+        'storage',
+        (event) => {
+            if (event.storageArea === storage && event.key === storageKey) {
+                readFromStorage();
+            }
+        },
+        false,
+    );
+    return {
+        reset: () => {
+            persistToStorage();
+        },
+        set: (key) => {
+            if (options.keys && !options.keys.includes(key)) return;
+            persistToStorage();
+        },
+        delete: (key) => {
+            if (options.keys && !options.keys.includes(key)) return;
+            persistToStorage();
+        },
+    };
+};
+
+/** Persist list store content to browser storage. */
+export const persistListLocally = <T>(
+    storageKey: string,
+    {
+        serialize = JSON.stringify,
+        deserialize = JSON.parse,
+        storage = localStorage,
+        ...options
+    }: PersistListLocallyOptions<T> = {},
+): ListStorePlugin<T> => (store: Store<Record<string, T>>) => {
+    const readFromStorage = () => {
+        try {
+            const stored = storage.getItem(storageKey);
+            if (!stored) return;
+            const data = deserialize(stored) as Record<string, T>;
+
+            for (const key of Object.keys(data)) {
+                if (key in data) {
+                    store.set(key, data[key]!);
+                } else {
+                    store.delete(key);
+                }
+            }
+        } catch (error) {
+            options.logger?.error(error);
+        }
+    };
+    let debounce: ReturnType<typeof setTimeout>;
+    const persistToStorage = () => {
+        clearTimeout(debounce);
+        debounce = setTimeout(() => {
+            try {
+                const data = store.state;
                 storage.setItem(storageKey, serialize(data));
             } catch (error) {
                 options.logger?.error(error);

--- a/packages/stores/src/stores/createListStore.ts
+++ b/packages/stores/src/stores/createListStore.ts
@@ -1,6 +1,6 @@
 import { $data } from '../symbols';
 import { createStore } from './createStore';
-import type { Plugin } from '../types';
+import type { ListStorePlugin } from '../types';
 
 /** A store for holding a list of objects. */
 export interface ListStore<T extends object> {
@@ -54,7 +54,7 @@ export interface ListStore<T extends object> {
      */
     readonly [$data]: Readonly<Map<string, T>>;
     /** Registers a subscription that will be called whenever the user gets, sets, or resets a value. */
-    use(...plugins: Plugin<T>[]): () => void;
+    use(...plugins: ListStorePlugin<T>[]): () => void;
 }
 
 /** Create a new list store with the given initial state. */
@@ -72,7 +72,7 @@ export const createListStore = <T extends object>(
         return false;
     };
 
-    const use = (...subscriptions: Plugin<T>[]): (() => void) => {
+    const use = (...subscriptions: ListStorePlugin<T>[]): (() => void) => {
         const unsubscribes = subscriptions.reduce<Array<() => void>>(
             (acc, plugin) => {
                 const subscription = plugin(store);

--- a/packages/stores/src/types.ts
+++ b/packages/stores/src/types.ts
@@ -43,6 +43,9 @@ export interface OnChangeHandler<StoreType> {
 }
 
 export type Plugin<T> = (store: Store<T>) => Subscription<T>;
+export type ListStorePlugin<T> = (
+    store: Store<Record<string, T>>,
+) => Subscription<T>;
 
 /** An interface for creating subscriptions on the store. */
 export interface Subscription<StoreType> {


### PR DESCRIPTION
- copied use() method usage from Store.ts
- create ListStorePlugin type
- create PersistListLocallyOptions which extends PersistLocallyOptions
- create persistListLocall and add to export
- add persistListLocally