### PR TITLE
feat: enhance es-popover auto-positioning

### DIFF
--- a/packages/components/src/components/es-popover/es-popover.tsx
+++ b/packages/components/src/components/es-popover/es-popover.tsx
@@ -300,22 +300,23 @@ export class Popover {
         await popper.loaded();
         await this.positionPopper();
 
-        this.autoUpdateCleanup = autoUpdate(
-            this.attachTo ?? this.getParentNode()!,
-            this.popperShadow!,
-            () => this.positionPopper(),
-        );
-
         this.attachDocumentListeners();
         setTimeout(this.enterPopper, 50);
     };
 
     private attachDocumentListeners = () => {
         this.detachAllowFocus = allowFocus(this.popperInner!);
+        this.autoUpdateCleanup = autoUpdate(
+            this.attachTo ?? this.getParentNode()!,
+            this.popperShadow!,
+            () => this.positionPopper(),
+        );
     };
 
     private detachDocumentListeners = () => {
         this.detachAllowFocus?.();
+        this.autoUpdateCleanup?.();
+        this.autoUpdateCleanup = undefined;
     };
 
     private positionPopper = async () => {
@@ -430,8 +431,6 @@ export class Popover {
         this.popperInner = undefined;
         this.popperArrow = undefined;
         this.attached = false;
-        this.autoUpdateCleanup?.();
-        this.autoUpdateCleanup = undefined;
     };
 
     private bubbleRequestClose = (e: any) => {


### PR DESCRIPTION
This PR addresses the issue described in [UI-95](https://linear.app/eventstore/issue/UI-95/dropdown-does-not-scroll-with-parent). 

The es-popover previously had an issue where it wouldn't scroll correctly with its parent container. This created an unideal user experience as the dropdown could detach from its reference point during scroll events.

To resolve this, we've implemented the [autoUpdate](https://floating-ui.com/docs/autoupdate) function from the `floating-ui` library in the `es-popover.tsx` file. The function automatically adjusts the position of the popover when the reference element or the viewport changes. This includes scenarios such as scrolling and window resizing.

Now, the popover behaves as expected and maintains its position relative to its reference element even during scrolling and window resizing.

Closes [UI-95](https://linear.app/eventstore/issue/UI-95/dropdown-does-not-scroll-with-parent).
