### PR TITLE
feat: Improve Mac Compatibility by Adding Yarn Cache

### DIFF
--- a/.yarn/cache/fsevents-patch-3340e2eb10-8.zip
+++ b/.yarn/cache/fsevents-patch-3340e2eb10-8.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1799807fd3c46bf8a480f38cdc9167580e203445956052633cbd7400e558a034
+size 23675

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,11 +8,11 @@ plugins:
 
 supportedArchitectures:
   cpu:
-    - arm
+    - current
     - arm64
     - x64
-    - ia32
   os:
+    - current  
     - darwin
     - linux
     - win32

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,15 @@ plugins:
     - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
       spec: '@yarnpkg/plugin-version'
 
+supportedArchitectures:
+  cpu:
+    - arm
+    - arm64
+    - x64
+    - ia32
+  os:
+    - darwin
+    - linux
+    - win32
+
 yarnPath: .yarn/releases/yarn-3.1.0.cjs


### PR DESCRIPTION
This PR modifies the yarn configuration in our repository to ensure consistent behavior across all major operating systems. By updating the supportedArchitectures setting, we now include packages specific not only to MacOS, but also to Linux and Windows.

As a result, running 'yarn' will include the necessary dependencies for all these platforms, resolving the MacOS-specific generation of the 'fsevents-path-3340e2eb10-8.zip' file and aligning the behavior for all systems. This change enhances the developer experience by minimizing system-specific inconsistencies.