### PR TITLE
feat: Enable setting entire store state

### DIFF
--- a/packages/stores/src/stores/createStore.test.ts
+++ b/packages/stores/src/stores/createStore.test.ts
@@ -505,7 +505,6 @@ describe('use subscriptions', () => {
     });
 });
 
-
 type State = Partial<{
     hola: string;
     name: string;
@@ -549,8 +548,14 @@ describe('store', () => {
             name: 'John',
         });
 
-        expect(() => { store.state = undefined as unknown as State }).toThrow(TypeError);
-        expect(() => { store.state = null as unknown as State }).toThrow(TypeError);
-        expect(() => { store.state = 'hello world' as State }).toThrow(TypeError);
+        expect(() => {
+            store.state = (undefined as unknown) as State;
+        }).toThrow(TypeError);
+        expect(() => {
+            store.state = (null as unknown) as State;
+        }).toThrow(TypeError);
+        expect(() => {
+            store.state = 'hello world' as State;
+        }).toThrow(TypeError);
     });
 });

--- a/packages/stores/src/stores/createStore.test.ts
+++ b/packages/stores/src/stores/createStore.test.ts
@@ -508,9 +508,10 @@ describe('use subscriptions', () => {
 type State = Partial<{
     hola: string;
     name: string;
+    message: string;
 }>;
 
-describe('store', () => {
+describe('assignment of state with object', () => {
     test('allows an object to be assigned', () => {
         const store = createStore<State>({
             hola: 'hello',
@@ -557,5 +558,32 @@ describe('store', () => {
         expect(() => {
             store.state = 'hello world' as State;
         }).toThrow(TypeError);
+    });
+
+    test('subscriptions are properly triggered on state changes', () => {
+        const store = createStore<State>({
+            hola: 'hello',
+            name: 'John',
+        });
+
+        const subscription = {
+            set: jest.fn(),
+            insert: jest.fn(),
+            delete: jest.fn(),
+        };
+
+        // Register callbacks
+        store.on('set', subscription.set);
+        store.on('insert', subscription.insert);
+        store.on('delete', subscription.delete);
+
+        store.state = {
+            name: 'Peter',
+            message: '🔔',
+        };
+
+        expect(subscription.set).toHaveBeenCalledWith('name', 'Peter', 'John');
+        expect(subscription.delete).toHaveBeenCalledWith('hola');
+        expect(subscription.insert).toHaveBeenCalledWith('message', '🔔');
     });
 });

--- a/packages/stores/src/stores/createStore.test.ts
+++ b/packages/stores/src/stores/createStore.test.ts
@@ -504,3 +504,53 @@ describe('use subscriptions', () => {
         expect(subscription2.dispose).not.toHaveBeenCalled();
     });
 });
+
+
+type State = Partial<{
+    hola: string;
+    name: string;
+}>;
+
+describe('store', () => {
+    test('allows an object to be assigned', () => {
+        const store = createStore<State>({
+            hola: 'hello',
+            name: 'John',
+        });
+
+        const newState = {
+            hola: 'hola',
+            name: 'Sergio',
+        };
+
+        // assign newState to store.state
+        store.state = newState;
+
+        expect(store.state).toEqual(newState);
+    });
+
+    test('allows an empty object to be assigned', () => {
+        const store = createStore<State>({
+            hola: 'hello',
+            name: 'John',
+        });
+
+        const newState = {};
+
+        // assign newState to store.state
+        store.state = newState;
+
+        expect(store.state).toEqual(newState);
+    });
+
+    test('throws an error if a non-object is assigned', () => {
+        const store = createStore<State>({
+            hola: 'hello',
+            name: 'John',
+        });
+
+        expect(() => { store.state = undefined as unknown as State }).toThrow(TypeError);
+        expect(() => { store.state = null as unknown as State }).toThrow(TypeError);
+        expect(() => { store.state = 'hello world' as State }).toThrow(TypeError);
+    });
+});

--- a/packages/stores/src/stores/createStore.ts
+++ b/packages/stores/src/stores/createStore.ts
@@ -205,13 +205,15 @@ export const createStore = <T extends { [key: string]: any }>(
         },
         set state(value) {
             if (value === null || typeof value !== 'object') {
-                throw new TypeError(`Expected object, null, or undefined, got ${typeof value}`);
+                throw new TypeError(
+                    `Expected object, null, or undefined, got ${typeof value}`,
+                );
             }
-            
+
             const newProps = new Set<keyof T>(Object.keys(state));
 
             // Set new properties in the state object
-            newProps.forEach(prop => {
+            newProps.forEach((prop) => {
                 state[prop] = value[prop];
             });
 

--- a/packages/stores/src/stores/createStore.ts
+++ b/packages/stores/src/stores/createStore.ts
@@ -206,7 +206,7 @@ export const createStore = <T extends { [key: string]: any }>(
         set state(value) {
             if (value === null || typeof value !== 'object') {
                 throw new TypeError(
-                    `Expected object, null, or undefined, got ${typeof value}`,
+                    `Expected object, got ${typeof value}`,
                 );
             }
 

--- a/packages/stores/src/stores/createStore.ts
+++ b/packages/stores/src/stores/createStore.ts
@@ -208,7 +208,7 @@ export const createStore = <T extends { [key: string]: any }>(
                 throw new TypeError(`Expected object, got ${typeof value}`);
             }
 
-            const newProps = new Set<keyof T>(Object.keys(state));
+            const newProps = new Set<keyof T>(Object.keys(value));
 
             // Set new properties in the state object
             newProps.forEach((prop) => {

--- a/packages/stores/src/stores/createStore.ts
+++ b/packages/stores/src/stores/createStore.ts
@@ -10,13 +10,13 @@ import { $data } from '../symbols';
 +-------------------------------v-------------------------+
 |                       createStore                       |
 |            (creates and controls internal states)       |
-+--------+--------------------+-------------------+-------+
-         | uses               | uses              | uses
-+--------v--------+   +-------v------+    +-------v-------+
++--------+--------------------+------------------+--------+
+         | uses               | uses             | uses
++--------v--------+   +-------v------+    +------v--------+
 |   backingMap    |   |    state     |    |   handlers    |
 | (Stores data)   |   | (Proxy to    |    | (Handles      |
 |                 |   |  backingMap) |    |       events) |
-+-----------------+   +-------+------+    +-------+-------+
++-----------------+   +-------+------+    +------+--------+
                               | triggers         | triggered by
 +-----------------+           |                  |
 |       use       | <----------------------------+
@@ -205,9 +205,7 @@ export const createStore = <T extends { [key: string]: any }>(
         },
         set state(value) {
             if (value === null || typeof value !== 'object') {
-                throw new TypeError(
-                    `Expected object, got ${typeof value}`,
-                );
+                throw new TypeError(`Expected object, got ${typeof value}`);
             }
 
             const newProps = new Set<keyof T>(Object.keys(state));


### PR DESCRIPTION
Previously, `oauthStore.state = { codeVerifier, state, location };` is not possible. Setting the entire state with an object is not allowed. This limitation hindered the flexibility of state management and made it difficult to override the entire state of the proxy.

To resolve this, we've added a setter to the store that allows passing an entire object. This enhancement enables overriding the entire state of the proxy with a single operation.

Now, the store state can be easily manipulated and overridden as needed, improving the flexibility and ease of state management.

Closes [UI-96](https://linear.app/eventstore/issue/UI-89/allow-setting-entire-store-state).