### PR TITLE
Fix router actions not triggering

### DIFF
--- a/.changeset/cold-boats-appear.md
+++ b/.changeset/cold-boats-appear.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/router': patch
+---
+
+Fix bug where actions sometimes wouldn't trigger in some contexts

--- a/packages/router/src/utils/internalRouter.ts
+++ b/packages/router/src/utils/internalRouter.ts
@@ -234,7 +234,7 @@ export class InternalRouter {
     private queueActionOnElement = async (element: ReturnType<GetElement>) => {
         await element?.componentOnReady?.();
 
-        if (element?.ownerDocument?.contains(element)) {
+        if (element?.isConnected) {
             this.pendingActions.get(element)?.forEach((cb) => cb());
         }
 


### PR DESCRIPTION
- Check if element is connected using `isConnected` rather than checking if document contains it as an descendant

Before:

https://github.com/EventStore/Design-System/assets/11861797/c2657ff6-6a68-4c5b-b2a6-5d94b58b2d88

After:

https://github.com/EventStore/Design-System/assets/11861797/88ff13b5-2490-4271-be79-eaf9081e5d2f

fixes: UI-302