### PR TITLE
Prevent grid blowout on layout grid.

### DIFF
--- a/.changeset/hot-horses-protect.md
+++ b/.changeset/hot-horses-protect.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/layout': patch
+---
+
+Prevent grid blowout on layout grid.

--- a/packages/layout/src/css/root.css
+++ b/packages/layout/src/css/root.css
@@ -78,7 +78,7 @@ body {
     display: grid;
     grid-template-columns:
         var(--layout-sidebar-width)
-        auto
+        minmax(0, 1fr)
         var(--layout-toolbar-width);
     grid-template-rows:
         var(--layout-header-height) var(--layout-banner-height)


### PR DESCRIPTION
Change body column to `minmax(0, 1fr)` rather than `auto`.

Current:

https://github.com/EventStore/Design-System/assets/11861797/2fe49e03-9cbb-4391-9d9e-92eadb013bc9

After:

https://github.com/EventStore/Design-System/assets/11861797/a213ed29-f148-417b-b0e1-f697d7e42470

fixes: UI-307