### PR TITLE
Fix inconsistent scroll behaviour when setting / deleting `searchParams`

### DIFF
--- a/.changeset/great-ravens-trade.md
+++ b/.changeset/great-ravens-trade.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/router': patch
+---
+
+Fix inconsistent scroll behaviour when setting / deleting searchParams

--- a/packages/router/src/utils/searchParam.ts
+++ b/packages/router/src/utils/searchParam.ts
@@ -35,16 +35,8 @@ class SearchParam implements SearchParamTracker {
         }
 
         const search = this.params;
-
         search.set(this.key, value);
-        window[INTERNAL_ROUTER].history.replace(
-            {
-                ...window[INTERNAL_ROUTER].history.location,
-                search: search.toString(),
-            },
-            undefined,
-            false,
-        );
+        this.updateParams(search);
     };
 
     public delete = () => {
@@ -57,13 +49,19 @@ class SearchParam implements SearchParamTracker {
         }
 
         const search = this.params;
-
         search.delete(this.key);
+        this.updateParams(search);
+    };
 
-        window[INTERNAL_ROUTER].history.replace({
-            ...window[INTERNAL_ROUTER].history.location,
-            search: search.toString(),
-        });
+    private updateParams = (search: URLSearchParams) => {
+        window[INTERNAL_ROUTER].history.replace(
+            {
+                ...window[INTERNAL_ROUTER].history.location,
+                search: search.toString(),
+            },
+            undefined,
+            false,
+        );
     };
 
     private get params(): URLSearchParams {


### PR DESCRIPTION
`scrollParam.delete`  and `scrollParam.set` have different scroll behaviour, with `delete` resetting the window scroll to 0. 
This PR standardises on not scrolling.

Before:

https://github.com/EventStore/Design-System/assets/11861797/dbc3031b-7881-49af-b338-34f22538c281

After:


https://github.com/EventStore/Design-System/assets/11861797/103ced39-6719-433c-bdb0-955a78680dbd

Fixes: UI-308