### PR TITLE
Fully move icon-manager to es modules

### DIFF
--- a/.changeset/brave-papayas-return.md
+++ b/.changeset/brave-papayas-return.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/icon-manager': patch
+---
+
+Fixed icon-manager not working due to incorrect es-modules.

--- a/.yarn/cache/case-anything-npm-2.1.10-dbbea03b9e-eff2769d7d.zip
+++ b/.yarn/cache/case-anything-npm-2.1.10-dbbea03b9e-eff2769d7d.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:068977ae1c667564e941fc252120897f32ef4dd933d29411d2aae648340e76b8
-size 13268

--- a/.yarn/cache/case-anything-npm-2.1.13-ead887fee0-c39c69d7e4.zip
+++ b/.yarn/cache/case-anything-npm-2.1.13-ead887fee0-c39c69d7e4.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86c41ba1a575c783493bf389fb32d68fc9f870078d13d610307c859674b6918f
+size 11235

--- a/tools/icon-manager/package.json
+++ b/tools/icon-manager/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "description": "Automated icon inclusion for Event Store design system",
     "license": "Apache-2.0",
+    "type": "module",
     "bin": {
         "icon": "./dist/index.js"
     },
@@ -22,7 +23,7 @@
         "fix": "yarn g:fix"
     },
     "dependencies": {
-        "case-anything": "^2.1.10",
+        "case-anything": "^2.1.13",
         "clipboardy": "^2.3.0",
         "prettier": "^3.0.0",
         "semver": "^7.5.2",

--- a/tools/icon-manager/src/commands/addIcon.ts
+++ b/tools/icon-manager/src/commands/addIcon.ts
@@ -1,23 +1,23 @@
-import { writeFile } from 'fs/promises';
-import { cwd } from 'process';
-import { resolve, join, isAbsolute } from 'path';
+import { writeFile } from 'node:fs/promises';
+import { cwd } from 'node:process';
+import { resolve, join, isAbsolute } from 'node:path';
 
 import {
     addToIndex,
     isInIndex,
     readAliasesFromIndex,
     removeAliasFromIndex,
-} from '../utils/indexFile';
-import { prettify } from '../utils/prettify';
-import { loadIcon } from '../utils/loadIcon';
+} from '../utils/indexFile.js';
+import { prettify } from '../utils/prettify.js';
+import { loadIcon } from '../utils/loadIcon.js';
 import {
     createDeclarationIfMissing,
     createDirIfMissing,
-} from '../utils/scaffold';
-import { componentMetadata } from '../utils/componentMetadata';
+} from '../utils/scaffold.js';
+import { componentMetadata } from '../utils/componentMetadata.js';
 
-import { convertToComponent } from '../components/icon';
-import { failure, info, success } from '../utils/finish';
+import { convertToComponent } from '../components/icon.js';
+import { failure, info, success } from '../utils/finish.js';
 
 interface AddIconOptions {
     name: string;

--- a/tools/icon-manager/src/commands/aliasIcon.ts
+++ b/tools/icon-manager/src/commands/aliasIcon.ts
@@ -1,8 +1,8 @@
-import { cwd } from 'process';
-import { resolve, isAbsolute } from 'path';
+import { cwd } from 'node:process';
+import { resolve, isAbsolute } from 'node:path';
 
-import { addAliasToIndex } from '../utils/indexFile';
-import { failure, success } from '../utils/finish';
+import { addAliasToIndex } from '../utils/indexFile.js';
+import { failure, success } from '../utils/finish.js';
 
 interface AliasIconOptions {
     name: string;

--- a/tools/icon-manager/src/commands/display.ts
+++ b/tools/icon-manager/src/commands/display.ts
@@ -1,19 +1,29 @@
 /* eslint-disable no-console */
-import { createServer, type RequestListener } from 'http';
-import { join, dirname, resolve, isAbsolute, extname, basename } from 'path';
-import { readFile, stat } from 'fs/promises';
-import { watch } from 'fs';
-import { cwd } from 'process';
-import type { AddressInfo } from 'net';
-import { EventEmitter } from 'stream';
+import { createServer, type RequestListener } from 'node:http';
+import {
+    join,
+    dirname,
+    resolve,
+    isAbsolute,
+    extname,
+    basename,
+} from 'node:path';
+import { readFile, stat } from 'node:fs/promises';
+import { watch } from 'node:fs';
+import { cwd } from 'node:process';
+import type { AddressInfo } from 'node:net';
+import { EventEmitter } from 'node:events';
+import { createRequire } from 'node:module';
 
-import { JsxEmit, ModuleKind, ScriptTarget, transpileModule } from 'typescript';
+import typescript from 'typescript';
+// 'typescript' is a CommonJS module, which may not support all module.exports as named exports.
+const { JsxEmit, ModuleKind, ScriptTarget, transpileModule } = typescript;
 
 import {
     type IndexFileDetails,
     readIndexFileDetails,
-} from '../utils/indexFile';
-import { debounce } from '../utils/debounce';
+} from '../utils/indexFile.js';
+import { debounce } from '../utils/debounce.js';
 
 interface DisplayOptions {
     dir: string;
@@ -201,6 +211,7 @@ const iconDetails: RequestHandler =
         }
     };
 
+const require = createRequire(import.meta.url);
 const esComponentsDir = join(
     dirname(require.resolve('@eventstore-ui/components/package.json')),
     '/dist',

--- a/tools/icon-manager/src/commands/namespace.ts
+++ b/tools/icon-manager/src/commands/namespace.ts
@@ -1,9 +1,9 @@
-import { cwd } from 'process';
-import { resolve, isAbsolute } from 'path';
+import { cwd } from 'node:process';
+import { resolve, isAbsolute } from 'node:path';
 
-import { readIndexFileDetails, updateIndex } from '../utils/indexFile';
+import { readIndexFileDetails, updateIndex } from '../utils/indexFile.js';
 
-import { failure, success } from '../utils/finish';
+import { failure, success } from '../utils/finish.js';
 
 interface SetNamespaceOptions {
     dir: string;

--- a/tools/icon-manager/src/commands/regenerate.ts
+++ b/tools/icon-manager/src/commands/regenerate.ts
@@ -1,9 +1,9 @@
-import { cwd } from 'process';
-import { resolve, isAbsolute } from 'path';
+import { cwd } from 'node:process';
+import { resolve, isAbsolute } from 'node:path';
 
-import { regenerateIndex } from '../utils/indexFile';
+import { regenerateIndex } from '../utils/indexFile.js';
 
-import { failure, info, success } from '../utils/finish';
+import { failure, info, success } from '../utils/finish.js';
 
 interface RegenerateOptions {
     dir: string;

--- a/tools/icon-manager/src/commands/removeIcon.ts
+++ b/tools/icon-manager/src/commands/removeIcon.ts
@@ -1,14 +1,14 @@
-import { unlink } from 'fs/promises';
-import { cwd } from 'process';
-import { resolve, isAbsolute } from 'path';
+import { unlink } from 'node:fs/promises';
+import { cwd } from 'node:process';
+import { resolve, isAbsolute } from 'node:path';
 
 import {
     isInIndex,
     removeAliasFromIndex,
     removeFromIndex,
-} from '../utils/indexFile';
-import { componentMetadata } from '../utils/componentMetadata';
-import { failure, success } from '../utils/finish';
+} from '../utils/indexFile.js';
+import { componentMetadata } from '../utils/componentMetadata.js';
+import { failure, success } from '../utils/finish.js';
 
 interface RemoveIconOptions {
     name: string;

--- a/tools/icon-manager/src/commands/upgrade.ts
+++ b/tools/icon-manager/src/commands/upgrade.ts
@@ -1,23 +1,23 @@
-import { cwd } from 'process';
-import { mkdir, rename, rm, writeFile } from 'fs/promises';
-import { resolve, isAbsolute, join } from 'path';
+import { cwd } from 'node:process';
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import { resolve, isAbsolute, join } from 'node:path';
 
 import {
     checkIfIndexNeedsUpdate,
     regenerateIndex,
     readIndex,
     addToIndex,
-} from '../utils/indexFile';
+} from '../utils/indexFile.js';
 
-import { failure, info, success } from '../utils/finish';
-import { convertToComponent } from '../components/icon';
-import { loadIcon } from '../utils/loadIcon';
-import { prettify } from '../utils/prettify';
+import { failure, info, success } from '../utils/finish.js';
+import { convertToComponent } from '../components/icon.js';
+import { loadIcon } from '../utils/loadIcon.js';
+import { prettify } from '../utils/prettify.js';
 import {
     createDirIfMissing,
     createDeclarationIfMissing,
-} from '../utils/scaffold';
-import { version } from '../utils/version';
+} from '../utils/scaffold.js';
+import { version } from '../utils/version.js';
 
 interface UpgradeOptions {
     dir: string;

--- a/tools/icon-manager/src/components/icon.ts
+++ b/tools/icon-manager/src/components/icon.ts
@@ -1,5 +1,5 @@
-import type { ComponentMetadata } from '../utils/componentMetadata';
-import type { Loaded } from '../utils/loadIcon';
+import type { ComponentMetadata } from '../utils/componentMetadata.js';
+import type { Loaded } from '../utils/loadIcon.js';
 
 export const convertToComponent = (
     { kind, content }: Loaded,

--- a/tools/icon-manager/src/components/loader.ts
+++ b/tools/icon-manager/src/components/loader.ts
@@ -1,4 +1,4 @@
-import type { IndexMap } from '../utils/indexFile';
+import type { IndexMap } from '../utils/indexFile.js';
 
 export const convertToLoader = (
     indexMap: IndexMap,

--- a/tools/icon-manager/src/index.ts
+++ b/tools/icon-manager/src/index.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-import * as yargs from 'yargs';
-import { addIcon } from './commands/addIcon';
-import { aliasIcon } from './commands/aliasIcon';
-import { setNamespace } from './commands/namespace';
-import { removeIcon } from './commands/removeIcon';
-import { upgrade } from './commands/upgrade';
-import { display } from './commands/display';
-import { regenerate } from './commands/regenerate';
-import { version } from './utils/version';
+import yargs from 'yargs';
+import { addIcon } from './commands/addIcon.js';
+import { aliasIcon } from './commands/aliasIcon.js';
+import { setNamespace } from './commands/namespace.js';
+import { removeIcon } from './commands/removeIcon.js';
+import { upgrade } from './commands/upgrade.js';
+import { display } from './commands/display.js';
+import { regenerate } from './commands/regenerate.js';
+import { version } from './utils/version.js';
 
 yargs
     .version(version)

--- a/tools/icon-manager/src/utils/exists.ts
+++ b/tools/icon-manager/src/utils/exists.ts
@@ -1,4 +1,4 @@
-import { stat } from 'fs/promises';
+import { stat } from 'node:fs/promises';
 
 export const fileExists = async (path: string) => {
     try {

--- a/tools/icon-manager/src/utils/indexFile.ts
+++ b/tools/icon-manager/src/utils/indexFile.ts
@@ -1,13 +1,13 @@
-import { readFile, unlink, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { gt, SemVer } from 'semver';
 
-import { version } from './version';
-import { prettify } from './prettify';
-import { convertToLoader } from '../components/loader';
-import type { ComponentMetadata } from './componentMetadata';
-import { fileExists } from './exists';
+import { version } from './version.js';
+import { prettify } from './prettify.js';
+import { convertToLoader } from '../components/loader.js';
+import type { ComponentMetadata } from './componentMetadata.js';
+import { fileExists } from './exists.js';
 
 export type IndexMap = Map<string, ComponentMetadata>;
 export interface IndexFileDetails {

--- a/tools/icon-manager/src/utils/loadIcon.ts
+++ b/tools/icon-manager/src/utils/loadIcon.ts
@@ -1,10 +1,10 @@
-import { readFile } from 'fs/promises';
-import { cwd } from 'process';
-import { resolve, isAbsolute, parse } from 'path';
+import { readFile } from 'node:fs/promises';
+import { cwd } from 'node:process';
+import { resolve, isAbsolute, parse } from 'node:path';
 
 import * as clipboardy from 'clipboardy';
-import { optimiseSVG } from './optimiseSVG';
-import { fileExists } from './exists';
+import { optimiseSVG } from './optimiseSVG.js';
+import { fileExists } from './exists.js';
 
 export interface Loaded {
     kind: 'jsx' | 'svg';

--- a/tools/icon-manager/src/utils/prettify.ts
+++ b/tools/icon-manager/src/utils/prettify.ts
@@ -1,4 +1,4 @@
-import { extname } from 'path';
+import { extname } from 'node:path';
 import { type BuiltInParserName, resolveConfig, format } from 'prettier';
 
 const chooseParser = (destination: string): BuiltInParserName | undefined => {

--- a/tools/icon-manager/src/utils/scaffold.ts
+++ b/tools/icon-manager/src/utils/scaffold.ts
@@ -1,8 +1,9 @@
-import { mkdir, writeFile } from 'fs/promises';
-import { parse } from 'path';
-import { join } from 'path/posix';
-import { declaration } from '../components/declaration';
-import { dirExists, fileExists } from './exists';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { parse } from 'node:path';
+import { join } from 'node:path/posix';
+
+import { declaration } from '../components/declaration.js';
+import { dirExists, fileExists } from './exists.js';
 
 export const createDirIfMissing = async (directory: string) => {
     const { dir } = parse(directory);

--- a/tools/icon-manager/src/utils/version.ts
+++ b/tools/icon-manager/src/utils/version.ts
@@ -1,5 +1,8 @@
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export const version = JSON.parse(
     readFileSync(join(__dirname, '../../package.json'), 'utf-8'),

--- a/tools/icon-manager/tsconfig.json
+++ b/tools/icon-manager/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "lib": ["DOM", "DOM.Iterable", "ES2020"],
-        "moduleResolution": "Node",
+        "moduleResolution": "NodeNext",
         "module": "ES2020",
         "target": "ES2020",
         "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,7 +1840,7 @@ __metadata:
     "@types/node": ^18.11.18
     "@types/semver": ^7.3.9
     "@types/svgo": ^2.6.3
-    case-anything: ^2.1.10
+    case-anything: ^2.1.13
     clipboardy: ^2.3.0
     jest: ^27.4.5
     prettier: ^3.0.0
@@ -3793,10 +3793,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"case-anything@npm:^2.1.10":
-  version: 2.1.10
-  resolution: "case-anything@npm:2.1.10"
-  checksum: eff2769d7da178115be8ac2617ccbb850664ffd36f0a897e000d9dd5a64300141128f6a8fe024bd98ec63cc9173a72c1426bbcaac328c8a44109ce15f7c14a5e
+"case-anything@npm:^2.1.10, case-anything@npm:^2.1.13":
+  version: 2.1.13
+  resolution: "case-anything@npm:2.1.13"
+  checksum: c39c69d7e418337b6006a9692f13c2b257e907e867149a102e9beb7e9d2d52da14e754da1f4e4ce82a866d86d93047e522f64360bda54e7d7c308f4cdd736c3d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Icon manager was only partially moved to es modules, so node refused to run it. This PR completes the migration.
fixes: UI-319