### PR TITLE
 Don't select  `display: none;` or `display: contents;`  elements as scroll parent, as they cannot scroll.

### DIFF
--- a/.changeset/old-peaches-change.md
+++ b/.changeset/old-peaches-change.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/utils': patch
+---
+
+BUGFIX: don't select `display: contents;` or `display: hidden;` elements as scroll parent, as they cannot scroll.

--- a/packages/utils/src/getScrollParent.ts
+++ b/packages/utils/src/getScrollParent.ts
@@ -29,11 +29,13 @@ const findParent = (node: Element): Element =>
 const canScroll = (node: Element) => {
     const style = getComputedStyle(node, null);
     return (
-        style.getPropertyValue('overflow') === 'scroll' ||
-        style.getPropertyValue('overflow') === 'auto' ||
-        style.getPropertyValue('overflow-y') === 'scroll' ||
-        style.getPropertyValue('overflow-y') === 'auto' ||
-        style.getPropertyValue('overflow-x') === 'scroll' ||
-        style.getPropertyValue('overflow-x') === 'auto'
+        style.getPropertyValue('display') !== 'hidden' &&
+        style.getPropertyValue('display') !== 'contents' &&
+        (style.getPropertyValue('overflow') === 'scroll' ||
+            style.getPropertyValue('overflow') === 'auto' ||
+            style.getPropertyValue('overflow-y') === 'scroll' ||
+            style.getPropertyValue('overflow-y') === 'auto' ||
+            style.getPropertyValue('overflow-x') === 'scroll' ||
+            style.getPropertyValue('overflow-x') === 'auto')
     );
 };


### PR DESCRIPTION
Sometimes a popover would hide itself as it would choose a `display: contents` element as it's scroll parent, which has no size.

fixes: UI-366 (properly)