### PR TITLE
`es-tabs` improvements and bug fixes

### DIFF
--- a/.changeset/tiny-paws-arrive.md
+++ b/.changeset/tiny-paws-arrive.md
@@ -1,0 +1,19 @@
+---
+'@eventstore-ui/components': minor
+---
+
+`es-tabs`
+
+**Features**
+
+-   Add an icon between tabs with the `interTabIcon` and `interTabIconSize` props.
+-   "header-end" slot added, for placing buttons alongside tabs
+
+**Improvements**
+
+-   Tab sizes are now tracked, so that the indicator resizes (without animating) when the tabs are resized.
+-   Tabs will now evenly collapse, and elipsis overflowing text
+
+**Bug fixes**
+
+-   `activeParam` prop can now be changed after initial render

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -768,6 +768,14 @@ export namespace Components {
          */
         "activeParam": string | false;
         /**
+          * Icon to be rendered between each tab.
+         */
+        "interTabIcon"?: IconDescription;
+        /**
+          * thu size of the icon to be rendered between each tab.
+         */
+        "interTabIconSize": number;
+        /**
           * A list of tabs.
          */
         "tabs": Tab[];
@@ -1973,6 +1981,14 @@ declare namespace LocalJSX {
           * Reflect the active tab to a search param of name. Set to false to disable.
          */
         "activeParam"?: string | false;
+        /**
+          * Icon to be rendered between each tab.
+         */
+        "interTabIcon"?: IconDescription;
+        /**
+          * thu size of the icon to be rendered between each tab.
+         */
+        "interTabIconSize"?: number;
         /**
           * Triggered when the active tab is changed. `detail` is the newly active tab.
          */

--- a/packages/components/src/components/es-icon/readme.md
+++ b/packages/components/src/components/es-icon/readme.md
@@ -79,6 +79,7 @@ Type: `Promise<void>`
  - [es-table](../tables/es-table)
  - [es-table-nested](../tables/es-table-nested)
  - [es-table-virtualized](../tables/es-table-virtualized)
+ - [es-tabs](../es-tabs)
  - [es-thinking-button](../es-thinking-button)
  - es-toast
 
@@ -96,6 +97,7 @@ graph TD;
   es-table --> es-icon
   es-table-nested --> es-icon
   es-table-virtualized --> es-icon
+  es-tabs --> es-icon
   es-thinking-button --> es-icon
   es-toast --> es-icon
   style es-icon fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/components/src/components/es-tabs/es-tabs.css
+++ b/packages/components/src/components/es-tabs/es-tabs.css
@@ -41,8 +41,13 @@
     }
 }
 
+header {
+    display: flex;
+    overflow: hidden;
+}
+
 .tab {
-    flex: 0 0 58px;
+    flex: 0 1 auto;
     position: relative;
     appearance: none;
     background-color: transparent;
@@ -57,6 +62,7 @@
     transition-duration: 500ms;
     transition-timing-function: ease;
     z-index: 1;
+    overflow: hidden;
 
     &::after {
         content: '';
@@ -118,4 +124,14 @@
     top: -2px;
     left: 0;
     z-index: 20000;
+}
+
+es-badge {
+    align-items: flex-start;
+}
+
+.elipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/packages/components/src/components/es-tabs/readme.md
+++ b/packages/components/src/components/es-tabs/readme.md
@@ -63,11 +63,13 @@ export default () => (
 
 ## Properties
 
-| Property            | Attribute      | Description                                                                                        | Type                  | Default     |
-| ------------------- | -------------- | -------------------------------------------------------------------------------------------------- | --------------------- | ----------- |
-| `active`            | `active`       | The currently active panel. By default it will take from the passed activeParam, or the first tab. | `string \| undefined` | `undefined` |
-| `activeParam`       | `active-param` | Reflect the active tab to a search param of name. Set to false to disable.                         | `boolean \| string`   | `'tab'`     |
-| `tabs` _(required)_ | --             | A list of tabs.                                                                                    | `Tab[]`               | `undefined` |
+| Property            | Attribute             | Description                                                                                        | Type                                                                 | Default     |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ----------- |
+| `active`            | `active`              | The currently active panel. By default it will take from the passed activeParam, or the first tab. | `string \| undefined`                                                | `undefined` |
+| `activeParam`       | `active-param`        | Reflect the active tab to a search param of name. Set to false to disable.                         | `boolean \| string`                                                  | `'tab'`     |
+| `interTabIcon`      | `inter-tab-icon`      | Icon to be rendered between each tab.                                                              | `[namespace: string \| symbol, name: string] \| string \| undefined` | `undefined` |
+| `interTabIconSize`  | `inter-tab-icon-size` | thu size of the icon to be rendered between each tab.                                              | `number`                                                             | `20`        |
+| `tabs` _(required)_ | --                    | A list of tabs.                                                                                    | `Tab[]`                                                              | `undefined` |
 
 
 ## Events
@@ -79,20 +81,22 @@ export default () => (
 
 ## Slots
 
-| Slot          | Description                                                  |
-| ------------- | ------------------------------------------------------------ |
-| `"[tabName]"` | Slots are created based off of the names of the passed tabs. |
+| Slot           | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| `"[tabName]"`  | Slots are created based off of the names of the passed tabs. |
+| `"header-end"` | After all the tabs.                                          |
 
 
 ## Shadow Parts
 
-| Part          | Description                 |
-| ------------- | --------------------------- |
-| `"active"`    | The active tab.             |
-| `"indicator"` | The sliding indicatior bar. |
-| `"panel"`     | Tab panels.                 |
-| `"tab"`       | Tabs.                       |
-| `"tablist"`   | The tab container.          |
+| Part               | Description                       |
+| ------------------ | --------------------------------- |
+| `"active"`         | The active tab.                   |
+| `"indicator"`      | The sliding indicatior bar.       |
+| `"inter-tab-icon"` | Icon between tabs (if specified). |
+| `"panel"`          | Tab panels.                       |
+| `"tab"`            | Tabs.                             |
+| `"tablist"`        | The tab container.                |
 
 
 ## CSS Custom Properties
@@ -110,11 +114,13 @@ export default () => (
 
 ### Depends on
 
+- [es-icon](../es-icon)
 - [es-badge](../es-badge)
 
 ### Graph
 ```mermaid
 graph TD;
+  es-tabs --> es-icon
   es-tabs --> es-badge
   es-badge --> es-counter
   style es-tabs fill:#f9f,stroke:#333,stroke-width:4px


### PR DESCRIPTION
**Features**

-   Add an icon between tabs with the `interTabIcon` and `interTabIconSize` props.
-   "header-end" slot added, for placing buttons alongside tabs

**Improvements**

-   Tab sizes are now tracked, so that the indicator resizes (without animating) when the tabs are resized.
-   Tabs will now evenly collapse, and elipsis overflowing text

**Bug fixes**

-   `activeParam` prop can now be changed after initial render


![image](https://github.com/EventStore/Design-System/assets/11861797/867423fe-dde2-4429-854d-438eb79435f6)
