### PR TITLE
[UI-45] Persist portaled elements when when `es-portal` is moved within the DOM

### DIFF
--- a/.changeset/metal-parrots-sparkle.md
+++ b/.changeset/metal-parrots-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/components': patch
+---
+
+Bug fix: Persist portaled elements when parent `es-portal` is moved in the DOM.

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -52,7 +52,8 @@ export namespace Components {
         "steps": boolean;
     }
     interface EsBackdrop {
-        "close": () => Promise<void>;
+        "cancelClose": () => Promise<void>;
+        "close": () => Promise<boolean>;
         "preventOverscroll": boolean;
         "renderNode": (node: RenderFunction) => Promise<void>;
         "showBackdrop": boolean;

--- a/packages/components/src/components/es-portal/es-portal.tsx
+++ b/packages/components/src/components/es-portal/es-portal.tsx
@@ -36,15 +36,14 @@ export class Portal {
     private portalledBackdrop?: HTMLEsBackdropElement;
 
     connectedCallback() {
-        if (this.open) {
-            this.attachElement();
-        }
+        if (!this.open) return;
+        this.portalledBackdrop?.cancelClose();
+        this.attachElement();
     }
 
     disconnectedCallback() {
-        if (this.open) {
-            this.detatchElement();
-        }
+        if (!this.open) return;
+        this.detatchElement();
     }
 
     /** @internal */
@@ -76,9 +75,10 @@ export class Portal {
     @Method() async detatchElement() {
         if (!this.portalledBackdrop) return;
         const backdrop = this.portalledBackdrop;
-        this.portalledBackdrop = undefined;
-        await backdrop.close();
-        backdrop.parentNode?.removeChild(backdrop);
+        if (await backdrop.close()) {
+            backdrop.parentNode?.removeChild(backdrop);
+            this.portalledBackdrop = undefined;
+        }
     }
 
     render() {


### PR DESCRIPTION
This PR fixes a bug where if an `es-portal` is moved in the DOM, it will exit it's existing modal, and enter a new modal. The behavior is now changed to cancel the exit of the modal, if the element is re-attached to the dom before the modal have exited:


## Before

https://github.com/EventStore/Design-System/assets/11861797/04a00cec-2c50-4e1e-bba7-86357e458dbf


## After

https://github.com/EventStore/Design-System/assets/11861797/120e0f61-4473-4592-89d2-032dba3eb7b5

