### PR TITLE
Fix Infinite Resize Issue in es-editor Caused by es-resize-observer

### DIFF
--- a/documentation/src/components/docs-usage/docs-usage.css
+++ b/documentation/src/components/docs-usage/docs-usage.css
@@ -44,5 +44,5 @@ es-tabs::part(panel) {
 }
 
 es-editor {
-    --editor-height: 100%;
+    --editor-height: calc(100% - 10px);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,9 +3998,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001538, caniuse-lite@npm:^1.0.30001541":
-  version: 1.0.30001621
-  resolution: "caniuse-lite@npm:1.0.30001621"
-  checksum: 238187b8565edd98b041829a4157ff23406e8b573a8f5a7f7d75fd6bd46c508e4d1a07eb4a0086cfa1bce2f45fcd3b08ea7ffc36584ef2b1d38f8215b7301853
+  version: 1.0.30001636
+  resolution: "caniuse-lite@npm:1.0.30001636"
+  checksum: 9e6c5ab4c20df31df36720dda77cf6a781549ac2ad844bc0a416b327a793da21486358a1f85fdd6c39e22d336f70aac3b0e232f5f228cdff0ceb6e3e1c5e98fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR addresses an issue where `this.editorInstance?.layout({ width, height })` was causing the `es-editor` component to expand indefinitely. This expansion triggered the `es-resize-observer` to emit another `sizeChanged` event, which in turn called `this.editorInstance?.layout({ width, height })` again, creating an infinite resize loop.
