### PR TITLE
Update .gitignore to Match Yarn Recommendations for Non-Zero-Installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,13 @@ log.txt
 *.sublime-workspace
 
 
-/.yarn/*
-!/.yarn/patches
-!/.yarn/plugins
-!/.yarn/releases
-!/.yarn/sdks
-/.pnp.*
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 .stencil/
 .idea/


### PR DESCRIPTION
This PR updates the `.gitignore` file to align with the recommended settings from the Yarn documentation for projects not using zero-installs.

https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
