### PR TITLE
fix publishing

### DIFF
--- a/.changeset/good-papayas-run.md
+++ b/.changeset/good-papayas-run.md
@@ -1,0 +1,19 @@
+---
+'@eventstore-ui/components': patch
+'@eventstore-ui/editor': patch
+'@eventstore-ui/fields': patch
+'@eventstore-ui/forms': patch
+'@eventstore-ui/illustrations': patch
+'@eventstore-ui/layout': patch
+'@eventstore-ui/router': patch
+'@eventstore-ui/stores': patch
+'@eventstore-ui/theme': patch
+'@eventstore-ui/utils': patch
+'@eventstore-ui/assets': patch
+'@eventstore-ui/configs': patch
+'@eventstore-ui/icon-manager': patch
+'@eventstore-ui/monaco-editor': patch
+'@eventstore-ui/typedoc-plugin-usage': patch
+---
+
+Fix publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,14 +48,6 @@ jobs:
             # It uses the Changesets GitHub Action to automate versioning and releases.
             - name: Create Release Pull Request
               uses: changesets/action@v1
-              with:
-                  # Executes the `changeset publish` command to create a new version tag for each updated
-                  # package and publish them to npm. These tags will be included in the new PR and will be applied when the PR is merged.is merged.
-                  publish: yarn changeset publish
-
-                  # This will create GitHub releases for each published package.
-                  # These releases will be created when the PR is merged and the new versions are published.
-                  createGithubReleases: true
               env:
                   # The GitHub token is used to authenticate with GitHub
                   # Setting: https://github.com/EventStore/Design-System/settings/actions
@@ -64,3 +56,8 @@ jobs:
                   # 2. Allow GiHub Actions to create and manage pull requests
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+            # will run the release command when applicable
+            - name: Publish
+              if: steps.changesets.outputs.hasChangesets == 'false'
+              run: yarn release

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,4 +15,6 @@ supportedArchitectures:
         - linux
         - win32
 
+npmPublishAccess: 'public'
+
 yarnPath: .yarn/releases/yarn-4.0.1.cjs

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "fix": "nx run-many --target=fix",
         "test": "nx run-many --target=test",
         "dev": "nx run dev --project=${0}",
+        "release": "yarn workspaces foreach --all --no-private npm publish",
         "docs": "nx run docs:build",
         "docs:serve": "nx run docs:serve",
         "changelog": "changeset"


### PR DESCRIPTION
Due to https://github.com/changesets/changesets/issues/1411 changesets is publishing with npm, rather than yarn, meaning that packages are being  published without their workspace dependencies being correctly resolved:

![image](https://github.com/user-attachments/assets/fe2b8edb-59e8-4967-954f-fb31d2ff45ef)

This has gone unnoticed until now, as we generally use peer dependencies between projects (and dev dependencies aren't resolved).

This PR sets up a custom publishing command:
https://github.com/changesets/action?tab=readme-ov-file#custom-publishing