### PR TITLE
Add tab name to panel and tab part.

### DIFF
--- a/.changeset/eight-deers-sleep.md
+++ b/.changeset/eight-deers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/components': patch
+---
+
+Add tab name to panel and tab part.

--- a/packages/components/src/components/es-tabs/es-tabs.tsx
+++ b/packages/components/src/components/es-tabs/es-tabs.tsx
@@ -19,7 +19,7 @@ import type { IconDescription } from '../es-icon/types';
 /**
  * A tabbed panel. Each panel can be targeted via a slot.
  * @slot [tabName] - Slots are created based off of the names of the passed tabs.
- * @part [tabName] - The panel and tab for that tab
+ * @part [tabName] - The tab and its corresponding panel.
  * @slot header-end - After all the tabs.
  * @part indicator - The sliding indicatior bar.
  * @part panel - Tab panels.

--- a/packages/components/src/components/es-tabs/es-tabs.tsx
+++ b/packages/components/src/components/es-tabs/es-tabs.tsx
@@ -19,6 +19,7 @@ import type { IconDescription } from '../es-icon/types';
 /**
  * A tabbed panel. Each panel can be targeted via a slot.
  * @slot [tabName] - Slots are created based off of the names of the passed tabs.
+ * @part [tabName] - The panel and tab for that tab
  * @slot header-end - After all the tabs.
  * @part indicator - The sliding indicatior bar.
  * @part panel - Tab panels.
@@ -110,7 +111,7 @@ export class EsTabs {
                     active: this.active === id,
                     drag_over: this.activeDragOver === id,
                 }}
-                part={this.active === id ? 'tab active' : 'tab'}
+                part={`tab ${id} ${this.active === id ? 'active' : ''}`}
                 onClick={this.setActive(id)}
                 ref={this.captureTab(id)}
                 onDragEnter={this.dragEnterTab(id)}
@@ -139,7 +140,7 @@ export class EsTabs {
                         [this.getActive()?.panelVariant ?? '']: true,
                     }}
                     role={'tabpanel'}
-                    part={'panel'}
+                    part={`panel ${this.active}`}
                 >
                     <div
                         role={'presentation'}

--- a/packages/components/src/components/es-tabs/readme.md
+++ b/packages/components/src/components/es-tabs/readme.md
@@ -91,6 +91,7 @@ export default () => (
 
 | Part               | Description                       |
 | ------------------ | --------------------------------- |
+| `"[tabName]"`      | The panel and tab for that tab    |
 | `"active"`         | The active tab.                   |
 | `"indicator"`      | The sliding indicatior bar.       |
 | `"inter-tab-icon"` | Icon between tabs (if specified). |

--- a/packages/components/src/components/es-tabs/readme.md
+++ b/packages/components/src/components/es-tabs/readme.md
@@ -89,15 +89,15 @@ export default () => (
 
 ## Shadow Parts
 
-| Part               | Description                       |
-| ------------------ | --------------------------------- |
-| `"[tabName]"`      | The panel and tab for that tab    |
-| `"active"`         | The active tab.                   |
-| `"indicator"`      | The sliding indicatior bar.       |
-| `"inter-tab-icon"` | Icon between tabs (if specified). |
-| `"panel"`          | Tab panels.                       |
-| `"tab"`            | Tabs.                             |
-| `"tablist"`        | The tab container.                |
+| Part               | Description                          |
+| ------------------ | ------------------------------------ |
+| `"[tabName]"`      | The tab and its corresponding panel. |
+| `"active"`         | The active tab.                      |
+| `"indicator"`      | The sliding indicatior bar.          |
+| `"inter-tab-icon"` | Icon between tabs (if specified).    |
+| `"panel"`          | Tab panels.                          |
+| `"tab"`            | Tabs.                                |
+| `"tablist"`        | The tab container.                   |
 
 
 ## CSS Custom Properties


### PR DESCRIPTION
This allows us to target individual panels and tabs:


```css
es-tabs::part(json)
```
![image](https://github.com/user-attachments/assets/a0b0594a-050a-4f00-815b-669b02b9b8a4)


```css
es-tabs::part(tab json)
```
![image](https://github.com/user-attachments/assets/1e40bf66-f5fe-4475-8830-0b29e4078f5c)

```css
es-tabs::part(panel json)
```
![image](https://github.com/user-attachments/assets/d0689fbe-9d64-4487-9a16-a6c44701608a)
