### PR TITLE
account for border width on both sides for icon-only buttons

### DIFF
--- a/packages/components/src/components/buttons/button.css
+++ b/packages/components/src/components/buttons/button.css
@@ -263,5 +263,5 @@ span {
 ::slotted(:where(es-icon, es-badge):not([slot]):only-child) {
     margin-left: calc(0px - var(--spacing));
     margin-right: calc(0px - var(--spacing));
-    width: calc(var(--height) - var(--border-width));
+    width: calc(var(--height) - calc(var(--border-width) * 2));
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/85fce80c-5d11-451b-bb67-c10da7939848)

After:
![image](https://github.com/user-attachments/assets/fb3e7253-2268-4b99-9432-2bb2d34e2868)
