### PR TITLE
`es-tabs`: Ensure that the active tab exists.

### DIFF
--- a/.changeset/fifty-jokes-flash.md
+++ b/.changeset/fifty-jokes-flash.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/components': patch
+---
+
+`es-tabs`: Ensure that the active tab exists.

--- a/packages/components/src/components/es-tabs/es-tabs.tsx
+++ b/packages/components/src/components/es-tabs/es-tabs.tsx
@@ -59,6 +59,7 @@ export class EsTabs {
 
     componentWillLoad() {
         this.setUpActiveParam(this.activeParam);
+        this.updateActiveIfNoMatchesTabs(this.tabs);
     }
 
     disconnectedCallback() {
@@ -88,6 +89,12 @@ export class EsTabs {
     updateActive(active?: string) {
         this.searchParam?.set(active);
         this.tabChange.emit(active);
+    }
+
+    @Watch('tabs')
+    updateActiveIfNoMatchesTabs(tabs: Tab[]) {
+        if (tabs.find(({ id }) => id === this.active)) return;
+        this.active = this.tabs[0].id;
     }
 
     renderTab = ({ title, id, badge }: Tab, i: number) => (


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/900dbb08-1334-459f-8284-ceee103f4b21

After:

https://github.com/user-attachments/assets/aff15b38-eb49-4579-a67b-721ca9ae19f3

