### PR TITLE
Fix dragging es-panel selects everything inside the panel [UI-209]

### DIFF
--- a/.changeset/dull-houses-tan.md
+++ b/.changeset/dull-houses-tan.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/layout': patch
+---
+
+Fix dragging handle in es-panel selects everything inside the panel

--- a/packages/layout/src/components/panel/es-panel/es-panel.css
+++ b/packages/layout/src/components/panel/es-panel/es-panel.css
@@ -42,6 +42,7 @@
 
     color: var(--color-contrast);
     z-index: 100;
+    user-select: none;
 }
 
 .cursor_guard {


### PR DESCRIPTION
This PR addresses an issue where dragging on the es-panel results in selecting all elements inside the panel, leading to unintended behavior. The fix ensures that panel elements remain intact during drag interactions without triggering selection of internal content.

Closes [UI-209](https://eventstore.aha.io/develop/features/UI-209)