### PR TITLE
Pin CI ubuntu version to fix puppeteer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     build:
         name: 'Build, Test & Lint'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
     pages:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         environment:
             name: github-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     build-and-test:
         uses: ./.github/workflows/ci.yml
     release:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: [build-and-test]
         steps:
             - name: Checkout repo


### PR DESCRIPTION
CI is failing with a pupeteer error, hopefully pinning the ubuntu version will fix this until we are ready to update.

![image](https://github.com/user-attachments/assets/54578f04-5f53-4d8b-aca3-df0a80454437)
