### PR TITLE
Improve styleability of `es-layout-link` and `es-layout-button`.

### DIFF
--- a/.changeset/calm-kangaroos-lie.md
+++ b/.changeset/calm-kangaroos-lie.md
@@ -1,0 +1,24 @@
+---
+'@eventstore-ui/layout': minor
+---
+
+Improve styleability of `es-layout-link` and `es-layout-button`.
+
+Changed:
+
+-   Use `focus-visible` rather than `focus`.
+
+Added parts:
+
+-   `counter` - The counter element, if rendered.
+-   `badge` - The badge element, if rendered.
+-   `icon` - The icon element, if rendered.
+
+Added css variables:
+
+-   `--icon-gap` - The space between the icon and the text
+-   `--icon-size` - The size of the icon.
+-   `--vertical-spacing` - The total space between one button and another.
+-   `--highlight-color` - The text color when the button is focused or hovered.
+-   `--highlight-background-color` - The background color when the button is focused or hovered.
+-   `--highlight-decoration` - The text decoration when the button is focused or hovered.

--- a/packages/layout/src/components/buttons/es-layout-button/es-layout-button.tsx
+++ b/packages/layout/src/components/buttons/es-layout-button/es-layout-button.tsx
@@ -18,6 +18,9 @@ import { bindPanelDetails, type PanelMode } from '../../panel';
 /**
  * A button for the sidebar, sidebar-dropdown, and header-dropdown.
  * @part button - The button element.
+ * @part counter - The counter element, if rendered.
+ * @part badge - The badge element, if rendered.
+ * @part icon - The icon element, if rendered.
  */
 @Component({
     tag: 'es-layout-button',
@@ -90,6 +93,7 @@ export class LayoutButton {
                 >
                     {this.count != null ? (
                         <es-counter
+                            part={'counter'}
                             count={this.count}
                             variant={'filled'}
                             color={this.alertLevel}
@@ -100,8 +104,9 @@ export class LayoutButton {
                                 count={this.alertLevel ? 1 : 0}
                                 variant={'dot'}
                                 color={this.alertLevel}
+                                part={'badge'}
                             >
-                                <es-icon icon={this.icon} />
+                                <es-icon part={'icon'} icon={this.icon} />
                             </es-badge>
                         )
                     )}

--- a/packages/layout/src/components/buttons/es-layout-button/readme.md
+++ b/packages/layout/src/components/buttons/es-layout-button/readme.md
@@ -145,9 +145,12 @@ Type: `Promise<boolean>`
 
 ## Shadow Parts
 
-| Part       | Description         |
-| ---------- | ------------------- |
-| `"button"` | The button element. |
+| Part        | Description                       |
+| ----------- | --------------------------------- |
+| `"badge"`   | The badge element, if rendered.   |
+| `"button"`  | The button element.               |
+| `"counter"` | The counter element, if rendered. |
+| `"icon"`    | The icon element, if rendered.    |
 
 
 ## Dependencies

--- a/packages/layout/src/components/buttons/es-layout-link/es-layout-link.tsx
+++ b/packages/layout/src/components/buttons/es-layout-link/es-layout-link.tsx
@@ -16,7 +16,9 @@ import { bindPanelDetails, type PanelMode } from '../../panel';
 /**
  * A link for the sidebar, sidebar-dropdown, and header-dropdown.
  * @part link - The link element.
- * @part counter - The counter element
+ * @part counter - The counter element, if rendered.
+ * @part badge - The badge element, if rendered.
+ * @part icon - The icon element, if rendered.
  */
 @Component({
     tag: 'es-layout-link',
@@ -111,8 +113,9 @@ export class LayoutLink {
                                 count={this.alertLevel ? 1 : 0}
                                 variant={'dot'}
                                 color={this.alertLevel}
+                                part={'badge'}
                             >
-                                <es-icon icon={this.icon} />
+                                <es-icon part={'icon'} icon={this.icon} />
                             </es-badge>
                         )
                     )}

--- a/packages/layout/src/components/buttons/es-layout-link/readme.md
+++ b/packages/layout/src/components/buttons/es-layout-link/readme.md
@@ -133,10 +133,12 @@ Type: `Promise<boolean>`
 
 ## Shadow Parts
 
-| Part        | Description         |
-| ----------- | ------------------- |
-| `"counter"` | The counter element |
-| `"link"`    | The link element.   |
+| Part        | Description                       |
+| ----------- | --------------------------------- |
+| `"badge"`   | The badge element, if rendered.   |
+| `"counter"` | The counter element, if rendered. |
+| `"icon"`    | The icon element, if rendered.    |
+| `"link"`    | The link element.                 |
 
 
 ## Dependencies

--- a/packages/layout/src/components/buttons/layout-button.css
+++ b/packages/layout/src/components/buttons/layout-button.css
@@ -3,10 +3,19 @@
 
     --blob-size: 30px;
     --gutter-size: 30px;
+    --icon-gap: 12px;
+    --icon-size: 24px;
+    --vertical-spacing: 20px;
+
     --default-color: var(--color-text);
-    --active-color: var(--color-secondary);
     --disabled-color: var(--color-shade-50);
+
+    --active-color: var(--color-secondary);
     --active-background-color: transparent;
+
+    --highlight-color: var(--color-text);
+    --highlight-background-color: transparent;
+    --highlight-decoration: underline;
 }
 
 :host([level='2']) :matches(a, button) {
@@ -31,7 +40,7 @@
 
 a,
 button {
-    padding: 10px;
+    padding: calc(var(--vertical-spacing) / 2);
     padding-left: var(--gutter-size);
     padding-right: var(--gutter-size);
     color: var(--default-color);
@@ -43,7 +52,10 @@ button {
     position: relative;
     overflow: hidden;
     outline-offset: -1px;
-    gap: 12px;
+    gap: var(--icon-gap);
+    transition:
+        color 500ms ease,
+        background-color 500ms ease;
 
     &::before {
         content: '';
@@ -73,8 +85,10 @@ button {
         background-color: var(--active-background-color);
 
         &:hover,
-        &:focus,
+        &:focus-visible,
         & {
+            color: var(--active-color);
+
             &::before {
                 transform: translateX(50%);
                 opacity: 1;
@@ -83,8 +97,10 @@ button {
     }
 
     &:hover,
-    &:focus {
-        text-decoration: underline;
+    &:focus-visible {
+        color: var(--highlight-color);
+        background-color: var(--highlight-background-color);
+        text-decoration: var(--highlight-decoration);
 
         &::before {
             transform: translateX(25%);
@@ -97,7 +113,7 @@ button {
         cursor: not-allowed;
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             text-decoration: none;
         }
 
@@ -113,6 +129,11 @@ button {
     overflow: hidden;
 }
 
+es-icon {
+    height: var(--icon-size);
+    width: var(--icon-size);
+}
+
 :host([mode='collapsed']) {
     --blob-size: 0;
 
@@ -123,7 +144,7 @@ button {
         padding-right: 0;
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             color: var(--active-color);
         }
     }


### PR DESCRIPTION
Changed:

-   Use `focus-visible` rather than `focus`.

Added parts:

-   `counter` - The counter element, if rendered.
-   `badge` - The badge element, if rendered.
-   `icon` - The icon element, if rendered.

Added css variables:

-   `--icon-gap` - The space between the icon and the text
-   `--icon-size` - The size of the icon.
-   `--vertical-spacing` - The total space between one button and another.
-   `--highlight-color` - The text color when the button is focused or hovered.
-   `--highlight-background-color` - The background color when the button is focused or hovered.
-   `--highlight-decoration` - The text decoration when the button is focused or hovered.
