### PR TITLE
Prevent layout items from losing their connection to asigned panel on DOM move.

### DIFF
--- a/.changeset/six-ravens-live.md
+++ b/.changeset/six-ravens-live.md
@@ -1,0 +1,5 @@
+---
+'@eventstore-ui/layout': patch
+---
+
+Bug fix: Prevent layout items from losing their connection to asigned panel on DOM move.

--- a/packages/layout/src/components/buttons/es-layout-button/es-layout-button.tsx
+++ b/packages/layout/src/components/buttons/es-layout-button/es-layout-button.tsx
@@ -61,7 +61,8 @@ export class LayoutButton {
 
     private unbindPanelMode?: () => void;
 
-    componentWillLoad() {
+    connectedCallback() {
+        this.unbindPanelMode?.();
         this.unbindPanelMode = bindPanelDetails(this.host, ({ mode }) => {
             this.panelMode = mode;
         });

--- a/packages/layout/src/components/buttons/es-layout-link/es-layout-link.tsx
+++ b/packages/layout/src/components/buttons/es-layout-link/es-layout-link.tsx
@@ -74,7 +74,8 @@ export class LayoutLink {
 
     private unbindPanelMode?: () => void;
 
-    componentWillLoad() {
+    connectedCallback() {
+        this.unbindPanelMode?.();
         this.unbindPanelMode = bindPanelDetails(this.host, ({ mode }) => {
             this.panelMode = mode;
         });

--- a/packages/layout/src/components/es-layout-hr/es-layout-hr.tsx
+++ b/packages/layout/src/components/es-layout-hr/es-layout-hr.tsx
@@ -9,14 +9,15 @@ import { bindPanelDetails, type PanelMode } from '../panel';
     styleUrl: 'es-layout-hr.css',
     shadow: true,
 })
-export class PageTitle {
+export class LayoutHR {
     @Element() host!: HTMLEsLayoutSectionElement;
 
     @State() panelMode: PanelMode = 'inline';
 
     private unbindMode?: () => void;
 
-    componentWillLoad() {
+    connectedCallback() {
+        this.unbindMode?.();
         this.unbindMode = bindPanelDetails(this.host, ({ mode }) => {
             this.panelMode = mode;
         });

--- a/packages/layout/src/components/es-layout-section/es-layout-section.tsx
+++ b/packages/layout/src/components/es-layout-section/es-layout-section.tsx
@@ -46,7 +46,8 @@ export class LayoutSection {
 
     private unbindPanelDetails?: () => void;
 
-    componentWillLoad() {
+    connectedCallback() {
+        this.unbindPanelDetails?.();
         this.unbindPanelDetails = bindPanelDetails(
             this.host,
             (PanelDetails) => {


### PR DESCRIPTION
Previously:

https://github.com/user-attachments/assets/5fbf8974-d70d-406b-ab02-e99e585eee1f

After this change:

https://github.com/user-attachments/assets/f190f40e-9500-49b8-8b14-f382b4d0d11f

