### PR TITLE
Improve tabs redesign

### DIFF
--- a/.changeset/few-peas-heal.md
+++ b/.changeset/few-peas-heal.md
@@ -1,0 +1,5 @@
+---
+'@kurrent-ui/layout': minor
+---
+
+`l2-panel-header` has new `hasTabs` prop to improve look when heading a panel with tabs.

--- a/.changeset/seven-singers-brake.md
+++ b/.changeset/seven-singers-brake.md
@@ -1,0 +1,8 @@
+---
+'@kurrent-ui/components': minor
+---
+
+Improved tabs design.
+
+-   `c2-tabs` has an improved design and layout.
+-   `c2-table-detail-header` has new `hasTabs` prop to improve look when heading a panel with tabs.

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -735,6 +735,10 @@ export namespace Components {
          */
         "data": any;
         /**
+          * If the panel has tabs.
+         */
+        "hasTabs": boolean;
+        /**
           * Passed to cell renderer as `parent`.
          */
         "identifier": string;
@@ -2369,6 +2373,10 @@ declare namespace LocalJSX {
           * The data to render.
          */
         "data": any;
+        /**
+          * If the panel has tabs.
+         */
+        "hasTabs"?: boolean;
         /**
           * Passed to cell renderer as `parent`.
          */

--- a/packages/components/src/components/tables/demos/table-detail-with-tabs.demo.tsx
+++ b/packages/components/src/components/tables/demos/table-detail-with-tabs.demo.tsx
@@ -1,0 +1,84 @@
+import { Component, h, Host, State } from '@stencil/core';
+
+import type { TableCells } from '../types';
+import type { Tab } from '../../tabs/types';
+
+interface DummyData {
+    name: string;
+    value: string;
+    amount: number;
+}
+
+/**
+ * Table Detail With Tabs
+ * @group Tables
+ */
+@Component({
+    tag: 'table-detail-with-tabs-demo',
+    styleUrl: './table-basic.css',
+    shadow: true,
+})
+export class TableDetailDemo {
+    @State() data: DummyData = {
+        name: 'Test Data',
+        value: 'something here',
+        amount: 12,
+    };
+
+    render() {
+        return (
+            <Host>
+                <c2-table-detail-header
+                    hasTabs
+                    titleCell={'name'}
+                    data={this.data}
+                    cells={this.cells}
+                />
+                <c2-tabs tabs={this.tabs}>
+                    <c2-table-detail
+                        slot={'details'}
+                        data={this.data}
+                        cells={this.cells}
+                    />
+                    <c2-table-detail
+                        slot={'details-2'}
+                        data={this.data}
+                        cells={this.cells}
+                        columns={['name']}
+                    />
+                </c2-tabs>
+            </Host>
+        );
+    }
+
+    private tabs: Tab[] = [
+        { id: 'details', title: 'Details' },
+        { id: 'details-2', title: 'More Details' },
+    ];
+
+    private cells: TableCells<DummyData> = {
+        name: {
+            title: 'Name',
+        },
+        value: {
+            title: 'Value',
+            cell: (h, { data }) => (
+                <div class={'some_class'}>
+                    <h1>{data.amount}</h1>
+                </div>
+            ),
+        },
+        amount: {
+            title: 'Amount',
+            width: 'max-content',
+            class: ({ amount }) => ({
+                amount: true,
+                large: amount >= 10,
+            }),
+        },
+        actions: {
+            title: 'Amount',
+            cell: (h) => <c2-button>{'Hello'}</c2-button>,
+        },
+    };
+}

--- a/packages/components/src/components/tables/table-detail-header/readme.md
+++ b/packages/components/src/components/tables/table-detail-header/readme.md
@@ -75,6 +75,7 @@ pre {
 | `actionsCell`        | `actions-cell` | Which cell to place in the top right as a list of actions. | `string`                                | `'actions'`       |
 | `cells` _(required)_ | --             | A record of table cell definitions.                        | `{ [x: string]: TableCell<any, any>; }` | `undefined`       |
 | `data` _(required)_  | `data`         | The data to render.                                        | `any`                                   | `undefined`       |
+| `hasTabs`            | `has-tabs`     | If the panel has tabs.                                     | `boolean`                               | `false`           |
 | `identifier`         | `identifier`   | Passed to cell renderer as `parent`.                       | `string`                                | `'detail-header'` |
 | `titleCell`          | `title-cell`   | Which cell to place as the title                           | `string`                                | `'title'`         |
 

--- a/packages/components/src/components/tables/table-detail-header/table-detail-header.css
+++ b/packages/components/src/components/tables/table-detail-header/table-detail-header.css
@@ -7,11 +7,17 @@
 c2-table-detail-header {
     display: flex;
     flex-direction: row;
-    padding-bottom: 20px;
+    padding-bottom: var(--spacing-2_5, 20px);
     border-bottom: 1px solid var(--color-shade-30);
     min-height: 61px;
     align-items: center;
     justify-content: center;
+
+    &[has-tabs] {
+        padding-bottom: var(--spacing-1_5, 12px);
+        min-height: 52px;
+        border-bottom: 0px;
+    }
 }
 
 .header_title {

--- a/packages/components/src/components/tables/table-detail-header/table-detail-header.tsx
+++ b/packages/components/src/components/tables/table-detail-header/table-detail-header.tsx
@@ -10,6 +10,8 @@ import type { TableCells } from '../types';
 export class TableDetailHeader {
     /** Passed to cell renderer as `parent`. */
     @Prop() identifier: string = 'detail-header';
+    /** If the panel has tabs. */
+    @Prop({ reflect: true }) hasTabs: boolean = false;
     /** The data to render. */
     @Prop() data!: any;
     /** Which cell to place as the title */

--- a/packages/components/src/components/tabs/tabs.css
+++ b/packages/components/src/components/tabs/tabs.css
@@ -54,8 +54,9 @@ header {
     color: var(--tab-color);
     font-weight: 700;
     font-size: 16px;
+    line-height: 1.5;
     border: 0;
-    padding: 20px;
+    padding: var(--spacing-1_5);
     cursor: pointer;
     outline: none;
     transition-property: color;
@@ -63,6 +64,10 @@ header {
     transition-timing-function: ease;
     z-index: 1;
     overflow: hidden;
+
+    &:first-child {
+        padding-left: 0;
+    }
 
     &::after {
         content: '';
@@ -96,7 +101,7 @@ header {
 
 .panel {
     border-top: 2px solid var(--border-color);
-    padding: 10px 30px;
+    padding: 0;
     flex: 1 1 100%;
     position: relative;
     min-height: 80px;

--- a/packages/components/src/components/tabs/types.ts
+++ b/packages/components/src/components/tabs/types.ts
@@ -8,6 +8,7 @@ export interface Tab {
     /** Function to determine if a dot badge should be displayed. */
     badge?: () => boolean;
     /**
+     * @deprecated No style difference
      * Apply styling to a panel:
      * - 'default': Default styling.
      * - 'no_pad': No padding.

--- a/packages/layout/src/components.d.ts
+++ b/packages/layout/src/components.d.ts
@@ -356,6 +356,10 @@ export namespace Components {
      * A header for `l2-panel`.
      */
     interface L2PanelHeader {
+        /**
+          * If the panel has tabs.
+         */
+        "hasTabs": boolean;
     }
     /**
      * A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.
@@ -1008,6 +1012,10 @@ declare namespace LocalJSX {
      * A header for `l2-panel`.
      */
     interface L2PanelHeader {
+        /**
+          * If the panel has tabs.
+         */
+        "hasTabs"?: boolean;
     }
     /**
      * A sidebar. Automatically sets `--layout-sidebar-width` based on it's own width.

--- a/packages/layout/src/components/panel-header/panel-header.css
+++ b/packages/layout/src/components/panel-header/panel-header.css
@@ -1,10 +1,15 @@
 :host {
     display: flex;
     flex-direction: row;
-    padding-bottom: 20px;
+    padding-bottom: var(--spacing-2_5, 20px);
     border-bottom: 1px solid var(--color-shade-30);
     align-items: center;
     justify-content: center;
+}
+
+:host([has-tabs]) {
+    padding-bottom: var(--spacing-1_5, 12px);
+    border-bottom: 0px;
 }
 
 h1 {

--- a/packages/layout/src/components/panel-header/panel-header.tsx
+++ b/packages/layout/src/components/panel-header/panel-header.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host } from '@stencil/core';
+import { Component, h, Host, Prop } from '@stencil/core';
 
 /**
  * A header for `l2-panel`.
@@ -12,6 +12,9 @@ import { Component, h, Host } from '@stencil/core';
     shadow: true,
 })
 export class YPanelHeader {
+    /** If the panel has tabs. */
+    @Prop({ reflect: true }) hasTabs: boolean = false;
+
     render() {
         return (
             <Host>

--- a/packages/layout/src/components/panel-header/readme.md
+++ b/packages/layout/src/components/panel-header/readme.md
@@ -35,6 +35,13 @@ export default () => (
 
 
 
+## Properties
+
+| Property  | Attribute  | Description            | Type      | Default |
+| --------- | ---------- | ---------------------- | --------- | ------- |
+| `hasTabs` | `has-tabs` | If the panel has tabs. | `boolean` | `false` |
+
+
 ## Slots
 
 | Slot        | Description                            |


### PR DESCRIPTION
- `c2-tabs` has an improved design and layout.
- `c2-table-detail-header` has new `hasTabs` prop to improve look when heading a panel with tabs.
- `l2-panel-header` has new `hasTabs` prop to improve look when heading a panel with tabs.

### Before

![Screenshot_select-area_20241213182055](https://github.com/user-attachments/assets/a8e0d485-5857-4872-87e0-399fae9f419b)

### After

![Screenshot_select-area_20241213183157](https://github.com/user-attachments/assets/06d01794-4c58-4c41-9421-31be5c547f63)
