### PR TITLE
Make `FieldChangeEvent` more flexible

### DIFF
--- a/.changeset/hungry-spies-sniff.md
+++ b/.changeset/hungry-spies-sniff.md
@@ -1,0 +1,26 @@
+---
+'@kurrent-ui/fields': minor
+---
+
+`FieldChangeEvent` is now more flexible.
+
+Previously, it only took the complete form type, and a key to the form:
+
+```ts
+interface MyForm {
+    something: number;
+    another: string;
+}
+
+const handleSomethingChange = (e: FieldChangeEvent<MyForm, 'something'>) => {
+    // e.details is now `{ name: "something", value: number }`
+};
+```
+
+Now, you can also pass a typing as a single value, so it is easier to use outside of a validatedForm context:
+
+```ts
+const handleSomethingChange = (e: FieldChangeEvent<number>) => {
+    // e.details is now `{ name: string, value: number }`
+};
+```

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -19,8 +19,11 @@ export interface FieldChange<T, N = string> {
     value: T;
 }
 
-export type FieldChangeEvent<T, N extends keyof T> = CustomEvent<
-    FieldChange<T[N], N>
->;
+export type FieldChangeEvent<
+    T,
+    N extends keyof T | void = void,
+> = N extends keyof T
+    ? CustomEvent<FieldChange<T[N], N>>
+    : CustomEvent<FieldChange<T>>;
 
 export type Templated = boolean | 'no-edit';


### PR DESCRIPTION
Previously, it only took the complete form type, and a key to the form:

```ts
interface MyForm {
    something: number;
    another: string;
}

const handleSomethingChange = (e: FieldChangeEvent<MyForm, 'something'>) => {
    // e.details is now `{ name: "something", value: number }`
};
```

Now, you can also pass a typing as a single value, so it is easier to use outside of a validatedForm context:

```ts
const handleSomethingChange = (e: FieldChangeEvent<number>) => {
    // e.details is now `{ name: string, value: number }`
};
```