### PR TITLE
Fix `listStore` updateOrSet

### DIFF
--- a/.changeset/ninety-dolls-rescue.md
+++ b/.changeset/ninety-dolls-rescue.md
@@ -1,0 +1,5 @@
+---
+'@kurrent-ui/stores': patch
+---
+
+Bug Fix: `updateOrSet` returns the current value as-is, in line with `update`

--- a/packages/stores/src/stores/createListStore.ts
+++ b/packages/stores/src/stores/createListStore.ts
@@ -151,7 +151,7 @@ export const createListStore = <T>(
         },
         updateOrSet: (id, updater, creator) => {
             if (id in state) {
-                state[id] = updater({ ...state[id] });
+                state[id] = updater(state[id]);
                 return true;
             }
             state[id] = creator();


### PR DESCRIPTION
Previously if you called `updateOrSet` on an array value, you got back an object. e.g. `["hello"]` -> `{ 0: "hello" }`