### PR TITLE
[UI-270] Adds new option `shouldValidateBranch` to `createValidatedForm` for helping to create branching forms.

### DIFF
--- a/.changeset/breezy-paws-hide.md
+++ b/.changeset/breezy-paws-hide.md
@@ -2,10 +2,10 @@
 '@kurrent-ui/forms': minor
 ---
 
-`createValidatedForm` has a new option `branchIsActive` for helping to create branching forms.
+`createValidatedForm` has a new option `shouldValidateBranch` for helping to create branching forms.
 
-When a parent validated form is validated, it will only call validation on a nested validated form if `branchIsActive` returns true (or is `undefined`).
-`branchIsActive` is passed the data of the top level form which had validation called on it, it's own data, and the reason for validating.
+When a parent validated form is validated, it will only call validation on a nested validated form if `shouldValidateBranch` returns true (or is `undefined`).
+`shouldValidateBranch` is passed the data of the top level form which had validation called on it, it's own data, and the reason for validating.
 
 Example usage
 
@@ -26,7 +26,7 @@ const form = createValidatedForm<DinnerForm, DinnerForm>({
             pineapple: true,
         },
         {
-            branchIsActive: (root) => root.mealType === 'pizza',
+            shouldValidateBranch: (root) => root.mealType === 'pizza',
         },
     ),
 });

--- a/.changeset/breezy-paws-hide.md
+++ b/.changeset/breezy-paws-hide.md
@@ -1,0 +1,33 @@
+---
+'@kurrent-ui/forms': minor
+---
+
+`createValidatedForm` has a new option `branchIsActive` for helping to create branching forms.
+
+When a parent validated form is validated, it will only call validation on a nested validated form if `branchIsActive` returns true (or is `undefined`).
+`branchIsActive` is passed the data of the top level form which had validation called on it, it's own data, and the reason for validating.
+
+Example usage
+
+```ts
+interface DinnerForm {
+    mealType: string;
+    pizzaToppings: {
+        pepperoni: boolean;
+        pineapple: boolean;
+    };
+}
+
+const form = createValidatedForm<DinnerForm, DinnerForm>({
+    mealType: '',
+    pizzaToppings: createValidatedForm<DinnerForm['pizzaToppings'], DinnerForm>(
+        {
+            pepperoni: true,
+            pineapple: true,
+        },
+        {
+            branchIsActive: (root) => root.mealType === 'pizza',
+        },
+    ),
+});
+```

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -6,6 +6,7 @@ export type {
     ValidationMessages,
     ValidatedForm,
     ValidatedFormOptions,
+    ValidatedFormControlOptions,
     Templated,
 } from './types';
 export { createValidatedForm } from './stores/createValidatedForm';

--- a/packages/forms/src/stores/createValidatedForm.ts
+++ b/packages/forms/src/stores/createValidatedForm.ts
@@ -15,7 +15,7 @@ import type {
     ValidatedFormControlOptions,
 } from '../types';
 import {
-    branchIsActive,
+    shouldValidateBranch,
     focusError,
     insertError,
     triggerValidation,
@@ -269,7 +269,7 @@ export const createValidatedForm = <T extends object, Root = any>(
                 if (isValidatedForm(field)) {
                     const dataToPass = rootData ?? fullData();
 
-                    if (!field[branchIsActive](dataToPass, trigger)) {
+                    if (!field[shouldValidateBranch](dataToPass, trigger)) {
                         continue;
                     }
 
@@ -626,9 +626,13 @@ export const createValidatedForm = <T extends object, Root = any>(
         [triggerValidation]: validate,
         [focusError]: focusFirstError,
         [insertError]: insertValidationError,
-        [branchIsActive]: (root, trigger) => {
-            if (controlOptions.branchIsActive == null) return true;
-            return controlOptions.branchIsActive(root, fullData(), trigger);
+        [shouldValidateBranch]: (root, trigger) => {
+            if (controlOptions.shouldValidateBranch == null) return true;
+            return controlOptions.shouldValidateBranch(
+                root,
+                fullData(),
+                trigger,
+            );
         },
     };
 };

--- a/packages/forms/src/symbols.ts
+++ b/packages/forms/src/symbols.ts
@@ -2,3 +2,4 @@ export const wDKey = Symbol('formdata');
 export const triggerValidation = Symbol('triggerValidation');
 export const focusError = Symbol('focusError');
 export const insertError = Symbol('insertError');
+export const branchIsActive = Symbol('branchIsActive');

--- a/packages/forms/src/symbols.ts
+++ b/packages/forms/src/symbols.ts
@@ -2,4 +2,4 @@ export const wDKey = Symbol('formdata');
 export const triggerValidation = Symbol('triggerValidation');
 export const focusError = Symbol('focusError');
 export const insertError = Symbol('insertError');
-export const branchIsActive = Symbol('branchIsActive');
+export const shouldValidateBranch = Symbol('shouldValidateBranch');

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -4,7 +4,7 @@ import type {
     focusError,
     insertError,
     triggerValidation,
-    branchIsActive,
+    shouldValidateBranch,
 } from './symbols';
 
 interface ChangeEventValue<T extends object, K extends keyof T> {
@@ -101,7 +101,7 @@ export interface ValidatedForm<T extends object, Root = any> {
         id: string,
     ) => void;
     /** @internal */
-    [branchIsActive]: (root: Root, trigger: ValidateOn) => boolean;
+    [shouldValidateBranch]: (root: Root, trigger: ValidateOn) => boolean;
 }
 
 interface BasicConnection<K extends string, V> {
@@ -219,7 +219,11 @@ export type ValidatedFormOptions<T extends object, Root = any> = {
 /** Additional global options for the entire validated form. */
 export interface ValidatedFormControlOptions<T, Root = any> {
     /** Called to see if the child should be validated when the parent form is validated or submitted. */
-    branchIsActive?: (root: Root, self: T, trigger: ValidateOn) => boolean;
+    shouldValidateBranch?: (
+        root: Root,
+        self: T,
+        trigger: ValidateOn,
+    ) => boolean;
 }
 
 /** Validation and setup options for fields */

--- a/packages/forms/src/utils/expandOptions.ts
+++ b/packages/forms/src/utils/expandOptions.ts
@@ -17,7 +17,7 @@ const defaults: InternalFieldOptions<any, any> = {
 };
 
 export const expandOptions = <T extends object>(
-    options: ValidatedFormOptions<T, any>,
+    options: ValidatedFormOptions<T>,
 ): InternalValidatedFormOptions<T> => {
     const expandedOptions: Record<
         string,

--- a/packages/forms/src/utils/expandOptions.ts
+++ b/packages/forms/src/utils/expandOptions.ts
@@ -16,8 +16,8 @@ const defaults: InternalFieldOptions<any, any> = {
     templated: false,
 };
 
-export const expandOptions = <T>(
-    options: ValidatedFormOptions<T>,
+export const expandOptions = <T extends object>(
+    options: ValidatedFormOptions<T, any>,
 ): InternalValidatedFormOptions<T> => {
     const expandedOptions: Record<
         string,


### PR DESCRIPTION
When a parent validated form is validated, it will only call validation on a nested validated form if `branchIsActive` returns true (or is `undefined`).
`branchIsActive` is passed the data of the top level form which had validation called on it, it's own data, and the reason for validating.

Example usage

```ts
interface DinnerForm {
    mealType: string;
    pizzaToppings: {
        pepperoni: boolean;
        pineapple: boolean;
    };
}

const form = createValidatedForm<DinnerForm, DinnerForm>({
    mealType: '',
    pizzaToppings: createValidatedForm<DinnerForm['pizzaToppings'], DinnerForm>(
        {
            pepperoni: true,
            pineapple: true,
        },
        {
            branchIsActive: (root) => root.mealType === 'pizza',
        },
    ),
});
```