### PR TITLE
[UI-271] Fix missing spacing fallbacks

### DIFF
--- a/.changeset/heavy-bananas-bow.md
+++ b/.changeset/heavy-bananas-bow.md
@@ -1,0 +1,6 @@
+---
+'@kurrent-ui/components': patch
+'@kurrent-ui/fields': patch
+---
+
+Fix missing spacing fallbacks

--- a/packages/components/src/components/actions/action.css
+++ b/packages/components/src/components/actions/action.css
@@ -4,7 +4,7 @@
     & > c2-button,
     & > c2-button-link {
         --current-color: var(--color-shade-60);
-        --spacing: var(--spacing-1);
+        --spacing: var(--spacing-1, 8px);
         --height: 32px;
 
         &[disabled] {
@@ -19,7 +19,7 @@
         --border-radius: 0;
         --align-inner: flex-start;
         --height: 46px;
-        --spacing: var(--spacing-1_5);
+        --spacing: var(--spacing-1_5, 12px);
         width: 100%;
 
         &::part(button),

--- a/packages/components/src/components/callout/callout.css
+++ b/packages/components/src/components/callout/callout.css
@@ -13,7 +13,7 @@
     display: block;
     background-color: var(--background-color);
     position: relative;
-    padding: var(--spacing-3);
+    padding: var(--spacing-3, 24px);
     color: var(--foreground-color);
     border-width: 4px;
     border-style: solid;
@@ -61,5 +61,5 @@ h1 {
     color: var(--foreground-color);
     margin: 0;
     line-height: 1.5;
-    margin-bottom: var(--spacing-1_5);
+    margin-bottom: var(--spacing-1_5, 12px);
 }

--- a/packages/components/src/components/tabs/tabs.css
+++ b/packages/components/src/components/tabs/tabs.css
@@ -43,7 +43,6 @@
 
 header {
     display: flex;
-    overflow: hidden;
 }
 
 .tab {
@@ -56,7 +55,7 @@ header {
     font-size: 16px;
     line-height: 1.5;
     border: 0;
-    padding: var(--spacing-1_5);
+    padding: var(--spacing-1_5, 12px);
     cursor: pointer;
     outline: none;
     transition-property: color;

--- a/packages/fields/src/components/form-footer/form-footer.css
+++ b/packages/fields/src/components/form-footer/form-footer.css
@@ -1,11 +1,11 @@
 :host {
     display: flex;
-    gap: var(--spacing-2);
+    gap: var(--spacing-2, 16px);
     align-items: center;
     justify-content: flex-end;
     border-top: 2px solid var(--color-shade-40);
-    padding: var(--spacing-3) 0;
-    margin-top: var(--spacing-4);
+    padding: var(--spacing-3, 24px) 0;
+    margin-top: var(--spacing-4, 32px);
     position: sticky;
     bottom: var(--layout-body-bottom, 0px);
     background-color: var(--color-background);

--- a/packages/fields/src/components/radio-card/input/radio-card-input.css
+++ b/packages/fields/src/components/radio-card/input/radio-card-input.css
@@ -140,14 +140,14 @@ input {
 
     text-align: left;
     text-transform: capitalize;
-    margin-bottom: var(--spacing-2);
+    margin-bottom: var(--spacing-2, 16px);
     display: block;
 }
 
 .group-inner + .group-title {
-    margin-top: var(--spacing-2);
+    margin-top: var(--spacing-2, 12px);
 }
 
 .default_card {
-    padding: var(--spacing-2);
+    padding: var(--spacing-2, 12px);
 }

--- a/packages/fields/src/components/switch/field/switch-field.css
+++ b/packages/fields/src/components/switch/field/switch-field.css
@@ -4,5 +4,5 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: var(--spacing-0_5);
+    gap: var(--spacing-0_5, 4px);
 }

--- a/packages/fields/src/demos/templated-form/templated-form.css
+++ b/packages/fields/src/demos/templated-form/templated-form.css
@@ -9,5 +9,5 @@
 
 form {
     display: block;
-    padding: var(--spacing-2);
+    padding: var(--spacing-2, 16px);
 }


### PR DESCRIPTION
When we added the `--spacing` vars, we should always add fallbacks, as the components should work without them being defined. A few were missed.

