### PR TITLE
Redesign table details

### DIFF
--- a/.changeset/gentle-mayflies-glow.md
+++ b/.changeset/gentle-mayflies-glow.md
@@ -1,0 +1,13 @@
+---
+'@kurrent-ui/components': minor
+---
+
+Table Details overhaul
+
+Table details has been redesigned to be
+
+-   More information dense
+-   Handle longer labels and data
+-   Fluidly size itself to it's available space
+
+Additionally, cell auto extract now handles more data types by attempting to convert all data type to a string, otherwise returning an empty placeholder.

--- a/packages/components/src/components/tables/demos/table-detail.demo.tsx
+++ b/packages/components/src/components/tables/demos/table-detail.demo.tsx
@@ -6,6 +6,22 @@ interface DummyData {
     name: string;
     value: string;
     amount: number;
+
+    eventSource: string;
+    groupName?: string;
+    resolveLinkTos: boolean;
+    startFrom: string;
+    messageTimeoutMilliseconds: number;
+    extraStatistics: boolean;
+    maxRetryCount: number;
+    liveBufferSize: number;
+    bufferSize: number;
+    readBatchSize: number;
+    checkPointAfterMilliseconds: number;
+    minCheckPointCount: number;
+    maxCheckPointCount: number;
+    maxSubscriberCount: number;
+    namedConsumerStrategy: string;
 }
 
 /**
@@ -22,6 +38,22 @@ export class TableDetailDemo {
         name: 'test',
         value: 'something here',
         amount: 12,
+        eventSource: 'my_stream',
+        groupName:
+            'my_group_has_a_very_long_name_so_I_have_been_set_to_full_width',
+        resolveLinkTos: true,
+        startFrom: '',
+        messageTimeoutMilliseconds: 1000,
+        extraStatistics: true,
+        maxRetryCount: 12,
+        liveBufferSize: 200,
+        bufferSize: 10,
+        readBatchSize: 20,
+        checkPointAfterMilliseconds: 1000,
+        minCheckPointCount: 5,
+        maxCheckPointCount: 20,
+        maxSubscriberCount: 100,
+        namedConsumerStrategy: 'RoundRobin',
     };
 
     render() {
@@ -57,6 +89,55 @@ export class TableDetailDemo {
                 large: amount >= 10,
             }),
         },
+
+        eventSource: {
+            title: 'Event Source',
+        },
+        groupName: {
+            title: 'Group Name',
+            variant: 'full-width',
+        },
+        resolveLinkTos: {
+            title: 'Resolve Links',
+        },
+        startFrom: {
+            title: 'Start From',
+        },
+        messageTimeoutMilliseconds: {
+            title: 'Message Timeout',
+        },
+        extraStatistics: {
+            title: 'Extra Statistics',
+        },
+        maxRetryCount: {
+            title: 'Max Retry Count',
+        },
+        liveBufferSize: {
+            title: 'Live Buffer Size',
+        },
+        bufferSize: {
+            title: 'Buffer Size',
+        },
+        readBatchSize: {
+            title: 'Read Batch Size',
+        },
+        checkPointAfterMilliseconds: {
+            title: 'Checkpoint After',
+            cell: (_, { data }) => `${data.checkPointAfterMilliseconds}ms`,
+        },
+        minCheckPointCount: {
+            title: 'Min Checkpoint Count',
+        },
+        maxCheckPointCount: {
+            title: 'Max Checkpoint Count',
+        },
+        maxSubscriberCount: {
+            title: 'Max Subscriber Count',
+        },
+        namedConsumerStrategy: {
+            title: 'Named Consumer Strategy',
+        },
+
         actions: {
             title: 'Amount',
             cell: (h) => <c2-button>{'Hello'}</c2-button>,

--- a/packages/components/src/components/tables/table-detail/readme.md
+++ b/packages/components/src/components/tables/table-detail/readme.md
@@ -63,6 +63,17 @@ export default () => (
 | `loading`            | `loading`    | Indicates if the loading indicators should be displayed                                 | `boolean \| undefined`                  | `undefined` |
 
 
+## CSS Custom Properties
+
+| Name                 | Description                                                             |
+| -------------------- | ----------------------------------------------------------------------- |
+| `--column-gap`       | The gap between columns.                                                |
+| `--grid-columns`     | Take full control of the grids column layout.                           |
+| `--max-columns`      | The maximum number of columns.                                          |
+| `--min-column-width` | The minimum width columns can be before reducing the number of columns. |
+| `--row-gap`          | The gap between rows.                                                   |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/components/src/components/tables/table-detail/table-detail.css
+++ b/packages/components/src/components/tables/table-detail/table-detail.css
@@ -1,3 +1,11 @@
+/**
+ * @prop --max-columns: The maximum number of columns.
+ * @prop --min-column-width: The minimum width columns can be before reducing the number of columns.
+ * @prop --column-gap: The gap between columns.
+ * @prop --row-gap: The gap between rows.
+ * @prop --grid-columns: Take full control of the grids column layout.
+ */
+
 *,
 *:before,
 *:after {
@@ -6,32 +14,55 @@
 
 c2-table-detail {
     display: block;
-    --grid-columns: repeat(2, 1fr);
+
+    --max-columns: 4;
+    --min-column-width: 250px;
+    --column-gap: var(--spacing-3, 24px);
+    --row-gap: var(--spacing-2, 16px);
+    --grid-columns: repeat(
+        auto-fill,
+        minmax(
+            max(
+                /* The maximum width a column can ever be is 100% / the maximum number of columns, with width of the gaps subtracted. */
+                    calc(
+                        (100% / var(--max-columns)) -
+                            (var(--column-gap) * (var(--max-columns) - 1))
+                    ),
+                var(--min-column-width)
+            ),
+            1fr
+        )
+    );
 }
 
 dl {
     display: grid;
     grid-template-columns: var(--grid-columns);
-    gap: 20px;
-    padding: 20px 0;
+    row-gap: var(--row-gap);
+    column-gap: var(--column-gap);
+    padding: 0;
+    margin: var(--spacing-2_5, 20px) 0;
 }
 
 .cell {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     line-height: 1.5;
+    gap: calc(var(--spacing-0_5, 4px) / 2);
 
     &.full_width {
         grid-column: 1 / -1;
+    }
+
+    & .none {
+        opacity: 0.6;
     }
 }
 
 dt {
     font-weight: bold;
     text-align: left;
-    flex: 0 0 150px;
     margin: 0;
-    margin-right: 20px;
 
     &::after {
         content: ':';
@@ -39,6 +70,6 @@ dt {
 }
 
 dd {
-    flex: 1 1 100%;
     margin: 0;
+    overflow-wrap: break-word;
 }

--- a/packages/components/src/components/tables/table-detail/table-detail.tsx
+++ b/packages/components/src/components/tables/table-detail/table-detail.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Host } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 import type { TableCells, TableCell } from '../types';
 import { autoExtract } from '../utils/autoExtract';
 
@@ -43,7 +43,7 @@ export class TableDetail {
                 parent: this.identifier,
             });
         } else {
-            return autoExtract(this.data, name);
+            return autoExtract(h, this.data, name);
         }
     };
 
@@ -53,34 +53,30 @@ export class TableDetail {
             Object.keys(this.cells).filter((name) => name !== 'actions');
 
         return (
-            <Host>
-                <dl class={{ loading: !!this.loading }}>
-                    {columns.map((name) => {
-                        const {
-                            title,
-                            variant,
-                            align = 'start',
-                        } = this.getCell(name);
-                        const variants =
-                            typeof variant === 'string'
-                                ? [variant]
-                                : variant ?? [];
+            <dl class={{ loading: !!this.loading }}>
+                {columns.map((name) => {
+                    const {
+                        title,
+                        variant,
+                        align = 'start',
+                    } = this.getCell(name);
+                    const variants =
+                        typeof variant === 'string' ? [variant] : variant ?? [];
 
-                        return (
-                            <div
-                                class={{
-                                    cell: true,
-                                    full_width: variants.includes('full-width'),
-                                    [align]: align !== 'start',
-                                }}
-                            >
-                                <dt>{title}</dt>
-                                <dd>{this.renderCell(name)}</dd>
-                            </div>
-                        );
-                    })}
-                </dl>
-            </Host>
+                    return (
+                        <div
+                            class={{
+                                cell: true,
+                                full_width: variants.includes('full-width'),
+                                [align]: align !== 'start',
+                            }}
+                        >
+                            <dt>{title}</dt>
+                            <dd>{this.renderCell(name)}</dd>
+                        </div>
+                    );
+                })}
+            </dl>
         );
     }
 

--- a/packages/components/src/components/tables/table-virtualized/table-virtualized.tsx
+++ b/packages/components/src/components/tables/table-virtualized/table-virtualized.tsx
@@ -313,7 +313,7 @@ export class Table {
                                   data,
                                   parent: this.identifier,
                               })
-                            : autoExtract(data, name)}
+                            : autoExtract(h, data, name)}
                     </div>
                 );
             }),

--- a/packages/components/src/components/tables/table.css
+++ b/packages/components/src/components/tables/table.css
@@ -257,6 +257,10 @@
     &.group_last {
         padding-right: 20px;
     }
+
+    & .none {
+        opacity: 0.6;
+    }
 }
 
 :where([role='details']) {

--- a/packages/components/src/components/tables/table/table.tsx
+++ b/packages/components/src/components/tables/table/table.tsx
@@ -216,7 +216,7 @@ export class Table {
                 parent: this.identifier,
             });
         } else {
-            return autoExtract(data, name);
+            return autoExtract(h, data, name);
         }
     };
 

--- a/packages/components/src/components/tables/utils/autoExtract.ts
+++ b/packages/components/src/components/tables/utils/autoExtract.ts
@@ -1,8 +1,0 @@
-export const autoExtract = (data: any, name: string) => {
-    const value = data?.[name];
-    return typeof value === 'string' ||
-        typeof value === 'bigint' ||
-        typeof value === 'number'
-        ? value
-        : null;
-};

--- a/packages/components/src/components/tables/utils/autoExtract.tsx
+++ b/packages/components/src/components/tables/utils/autoExtract.tsx
@@ -1,0 +1,11 @@
+import type { h as jsxFactory, VNode } from '@stencil/core';
+
+export const autoExtract = (
+    h: typeof jsxFactory,
+    data: any,
+    name: string,
+): VNode | string => {
+    const value = data?.[name];
+    const stringified = value != null ? String(value).trim() : '';
+    return stringified.length > 0 ? stringified : <i class={'none'}>{'-'}</i>;
+};


### PR DESCRIPTION
Table details has been redesigned to be

-   More information dense
-   Handle longer labels and data
-   Fluidly size itself to it's available space

Additionally, cell auto extract now handles more data types by attempting to convert all data type to a string, otherwise returning an empty placeholder.


------
**Before:**

![Screenshot_select-area_20250206173927](https://github.com/user-attachments/assets/94843204-de1c-4bb8-97d9-3e7271f13a24)

**After:**

![Screenshot_select-area_20250206174436](https://github.com/user-attachments/assets/e6ab89e5-21cf-4a6f-80ef-db3b8b21f0d4)

-----

**Before:**

![Screenshot_select-area_20250206172240](https://github.com/user-attachments/assets/647bf20c-387b-4cb1-951f-2bf39745d77e)

![Screenshot_select-area_20250206172256](https://github.com/user-attachments/assets/3574c7c5-ee8d-4c73-8119-1a56e641ebfc)


**After:**

https://github.com/user-attachments/assets/d8fbeed1-a413-4ab3-8e0e-5dabe424b27e


----

It's generally a drop in replacement, but some may need the cells re-arranged to improve the layout, for example:

![Screenshot_select-area_20250206174854](https://github.com/user-attachments/assets/f8673852-05de-462f-97db-31a91f089815)




