### PR TITLE
bump upload artifact to v4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,7 +54,7 @@ jobs:
               run: tar --directory documentation/www/ -cvf artifact.tar .
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: github-pages
                   path: ./artifact.tar


### PR DESCRIPTION
Pages action is failing due to:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/