### PR TITLE
chore: add typedoc plugin support metadata

### DIFF
--- a/.changeset/typedoc-plugin-usage-support-metadata.md
+++ b/.changeset/typedoc-plugin-usage-support-metadata.md
@@ -1,0 +1,5 @@
+---
+'@kurrent-ui/typedoc-plugin-usage': patch
+---
+
+Add npm homepage and issue tracker metadata.

--- a/tools/typedoc-plugin-usage/package.json
+++ b/tools/typedoc-plugin-usage/package.json
@@ -17,6 +17,10 @@
         "url": "git@github.com:EventStore/Design-System.git",
         "directory": "tools/typedoc-plugin-usage"
     },
+    "homepage": "https://github.com/kurrent-io/Design-System/tree/main/tools/typedoc-plugin-usage",
+    "bugs": {
+        "url": "https://github.com/kurrent-io/Design-System/issues"
+    },
     "scripts": {
         "build": "tsc --outDir ./dist --declaration",
         "dev": "tsc --outDir ./dist --declaration --watch",


### PR DESCRIPTION
## Summary
- add npm homepage metadata for `@kurrent-ui/typedoc-plugin-usage`
- add the repository issue tracker as `bugs.url`
- include a patch changeset for the package metadata update

## Validation
- `node -e "const p=require('./tools/typedoc-plugin-usage/package.json'); if(p.name!=='@kurrent-ui/typedoc-plugin-usage') throw new Error('bad name'); if(!p.homepage?.includes('kurrent-io/Design-System/tree/main/tools/typedoc-plugin-usage')) throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/kurrent-io/Design-System/issues') throw new Error('bad bugs'); console.log('metadata ok')"`
- `yarn install --immutable --mode=skip-build`
- `yarn workspace @kurrent-ui/typedoc-plugin-usage build`
- `yarn workspace @kurrent-ui/typedoc-plugin-usage pack --dry-run --json`
- `yarn eslint "tools/typedoc-plugin-usage/src/**/*.{ts,tsx}"`
- `yarn prettier -c tools/typedoc-plugin-usage/package.json .changeset/typedoc-plugin-usage-support-metadata.md`
- `git diff --check`

Note: `yarn workspace @kurrent-ui/typedoc-plugin-usage lint` could not run from my local checkout path because the shared `g:lint` script expands `cd $INIT_CWD` without quotes and my checkout path contains a space. I ran the equivalent underlying eslint/prettier commands listed above instead.